### PR TITLE
Refactor: component split and standalone postcard pages

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,7 +3,7 @@
   "configurations": [
     {
       "name": "jekyll",
-      "runtimeExecutable": "bundle",
+      "runtimeExecutable": "/opt/homebrew/opt/ruby/bin/bundle",
       "runtimeArgs": ["exec", "jekyll", "serve", "--port", "4001"],
       "port": 4001
     }

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 vendor
 .DS_Store
 .vscode
+.claude/launch.json

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,14 @@ mailing_address:
 plugins:
   - jekyll-feed
 
+# Post permalink structure
+defaults:
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      permalink: /postcards/:slug/
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/_includes/modals/postcard.html
+++ b/_includes/modals/postcard.html
@@ -1,0 +1,40 @@
+<!-- Postcard Modal -->
+<div id="postcard-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-label="Postcard viewer">
+  <div class="modal-backdrop"></div>
+  <div class="modal-postcard-details">
+    <div class="modal-top-row">
+      <span class="modal-postcard-number"></span>
+      <button class="modal-close-btn" aria-label="Close">
+        <img src="{{ '/assets/icons/close.svg' | relative_url }}" alt="Close" width="24" height="24">
+      </button>
+    </div>
+    <div class="modal-postcard-wrapper">
+      <div class="modal-card-container">
+        <div class="modal-card-front">
+          <img class="modal-front-img" src="" alt="">
+        </div>
+        <div class="modal-card-back">
+          <img class="modal-back-img" src="" alt="">
+        </div>
+      </div>
+    </div>
+    <div class="modal-bottom-section">
+      <div class="modal-accessibility-btns">
+        <button class="modal-action-btn modal-listen-btn" style="display:none">
+          <img src="{{ '/assets/icons/speaker.svg' | relative_url }}" alt="Listen" class="modal-action-icon">
+        </button>
+        <button class="modal-action-btn modal-read-btn" style="display:none">
+          <img src="{{ '/assets/icons/transcript.svg' | relative_url }}" alt="Read" class="modal-action-icon">
+        </button>
+      </div>
+      <button class="modal-action-btn modal-flip-btn">
+        <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="modal-action-icon">
+      </button>
+    </div>
+    <button class="modal-arrow-down" aria-label="Send a reply">
+      <svg width="32" height="16" viewBox="0 0 32 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M4 4L16 12L28 4" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+  </div>
+</div>

--- a/_includes/modals/reply.html
+++ b/_includes/modals/reply.html
@@ -1,0 +1,33 @@
+<!-- Reply Info Modal -->
+<div id="reply-modal" class="reply-overlay" role="dialog" aria-modal="true" aria-label="Send a reply">
+  <div class="reply-card">
+    <button class="reply-close" aria-label="Close">
+      <img src="{{ '/assets/icons/close.svg' | relative_url }}" alt="Close" width="20" height="20">
+    </button>
+    <div class="reply-content">
+      <h2 class="reply-title">To send a reply:</h2>
+      <p class="reply-instruction">Write the same number displayed above the postcard on the top left side of your reply postcard.</p>
+      <div class="reply-postcard-example">
+        <div class="reply-example-number">#123</div>
+        <div class="reply-example-body">
+          <div class="reply-example-left">
+            <p class="reply-example-meta">City, Date</p>
+            <p class="reply-example-heading">Your message</p>
+            <p class="reply-example-text">Write your story, thoughts, or reply here...</p>
+            <p class="reply-example-sign">/Your name (optional)</p>
+          </div>
+          <div class="reply-example-divider"></div>
+          <div class="reply-example-right">
+            <div class="reply-example-stamp"></div>
+            <div class="reply-example-address">
+              <p>{{ site.mailing_address.name }}</p>
+              <p>{{ site.mailing_address.street }}</p>
+              <p>{{ site.mailing_address.postal }}</p>
+              <p>{{ site.mailing_address.country }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/modals/send.html
+++ b/_includes/modals/send.html
@@ -1,0 +1,32 @@
+<!-- Send Postcard Modal -->
+<div id="send-modal" class="reply-overlay" role="dialog" aria-modal="true" aria-label="Send a postcard">
+  <div class="reply-card">
+    <button class="send-modal-close" aria-label="Close">
+      <img src="{{ '/assets/icons/close.svg' | relative_url }}" alt="Close" width="20" height="20">
+    </button>
+    <div class="reply-content">
+      <h2 class="reply-title">Send a postcard</h2>
+      <p class="reply-instruction">Write your story, thoughts, or message on a postcard and post it to:</p>
+      <div class="reply-postcard-example">
+        <div class="reply-example-body">
+          <div class="reply-example-left">
+            <p class="reply-example-meta">City, Date</p>
+            <p class="reply-example-heading">Your message</p>
+            <p class="reply-example-text">Write your story, thoughts, or message here...</p>
+            <p class="reply-example-sign">/Your name (optional)</p>
+          </div>
+          <div class="reply-example-divider"></div>
+          <div class="reply-example-right">
+            <div class="reply-example-stamp"></div>
+            <div class="reply-example-address">
+              <p>{{ site.mailing_address.name }}</p>
+              <p>{{ site.mailing_address.street }}</p>
+              <p>{{ site.mailing_address.postal }}</p>
+              <p>{{ site.mailing_address.country }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -2,18 +2,77 @@
 layout: default
 ---
 
-<article class="postcard-detail">
-  <header class="postcard-header">
-    <h1>{{ page.title }}</h1>
-    <div class="postcard-meta">
-      <p><strong>Date:</strong> {{ page.date | date: "%B %d, %Y" }}</p>
-      <p><strong>Country:</strong> {{ page.country }}</p>
-      <p><strong>Topic:</strong> {{ page.topic }}</p>
+<link rel="stylesheet" href="{{ '/assets/css/postcard.css' | relative_url }}">
+
+{% assign post_number = 0 %}
+{% for post in site.posts %}
+  {% assign post_number = post_number | plus: 1 %}
+  {% if post.url == page.url %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+
+<div class="postcard-page">
+  <a href="{{ '/posts.html' | relative_url }}" class="postcard-back-link">
+    <svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M6 1L1 6L6 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+    All postcards
+  </a>
+
+  <div class="postcard-viewer">
+    <span class="postcard-viewer-number">#{{ post_number }}</span>
+
+    <div class="postcard-viewer-wrapper">
+      <div class="postcard-viewer-container" id="card-container">
+        <div class="postcard-viewer-front">
+          {% if page.image-front %}
+            <img src="{{ page.image-front | relative_url }}" alt="{{ page.title }} - Front" class="postcard-viewer-img">
+          {% endif %}
+        </div>
+        <div class="postcard-viewer-back">
+          {% if page.image-back %}
+            <img src="{{ page.image-back | relative_url }}" alt="{{ page.title }} - Back" class="postcard-viewer-img">
+          {% endif %}
+        </div>
+      </div>
     </div>
-  </header>
-  <div class="postcard-images">
-    <img src="{{ page.image-front }}" alt="Postcard Front">
-    {{ content }}
-    <img src="{{ page.image-back }}" alt="Postcard Back">
+
+    <div class="postcard-viewer-actions">
+      <div class="postcard-viewer-accessibility">
+        <button class="postcard-viewer-btn postcard-listen-btn" style="display:none">
+          <img src="{{ '/assets/icons/speaker.svg' | relative_url }}" alt="Listen" class="postcard-viewer-icon">
+        </button>
+        <button class="postcard-viewer-btn postcard-read-btn" style="display:none">
+          <img src="{{ '/assets/icons/transcript.svg' | relative_url }}" alt="Read" class="postcard-viewer-icon">
+        </button>
+      </div>
+      <button class="postcard-viewer-btn postcard-flip-btn" id="flip-btn">
+        <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="postcard-viewer-icon">
+      </button>
+    </div>
   </div>
-</article>
+
+  <div class="postcard-meta">
+    <p class="postcard-meta-item"><strong>Country:</strong> {{ page.country }}</p>
+    <p class="postcard-meta-item"><strong>Topic:</strong> {{ page.topic }}</p>
+    <p class="postcard-meta-item"><strong>Date:</strong> {{ page.date | date: "%B %d, %Y" }}</p>
+  </div>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const container = document.getElementById('card-container');
+    const flipBtn = document.getElementById('flip-btn');
+    const listenBtn = document.querySelector('.postcard-listen-btn');
+    const readBtn = document.querySelector('.postcard-read-btn');
+    let isFlipped = false;
+
+    flipBtn.addEventListener('click', function() {
+      isFlipped = !isFlipped;
+      container.classList.toggle('flipped', isFlipped);
+      listenBtn.style.display = isFlipped ? 'flex' : 'none';
+      readBtn.style.display = isFlipped ? 'flex' : 'none';
+    });
+  });
+</script>

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -1,0 +1,158 @@
+/* Standalone postcard page (for direct visits / SEO) */
+
+.postcard-page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px 32px 48px;
+}
+
+.postcard-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-gray-4);
+  text-decoration: none;
+  margin-bottom: 24px;
+  transition: color 0.2s;
+}
+
+.postcard-back-link:hover {
+  color: var(--color-lavender);
+}
+
+/* Viewer */
+.postcard-viewer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.postcard-viewer-number {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 24px;
+  color: var(--color-gray-5);
+  align-self: flex-start;
+  margin-bottom: 8px;
+  padding-left: 4px;
+}
+
+.postcard-viewer-wrapper {
+  width: 100%;
+  perspective: 1200px;
+}
+
+.postcard-viewer-container {
+  position: relative;
+  width: 100%;
+  transform-style: preserve-3d;
+}
+
+.postcard-viewer-front {
+  width: 100%;
+  backface-visibility: hidden;
+  transition: opacity 0.3s ease;
+}
+
+.postcard-viewer-back {
+  width: 100%;
+  backface-visibility: hidden;
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.postcard-viewer-container.flipped .postcard-viewer-front {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.postcard-viewer-container.flipped .postcard-viewer-back {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.postcard-viewer-img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 2px;
+  box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15), 0px 4px 4px rgba(84, 65, 171, 0.2);
+}
+
+/* Action buttons */
+.postcard-viewer-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+  margin-top: 24px;
+}
+
+.postcard-viewer-accessibility {
+  display: flex;
+  gap: 16px;
+}
+
+.postcard-viewer-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: transform 0.15s;
+}
+
+.postcard-viewer-btn:hover {
+  transform: translateY(-2px);
+}
+
+.postcard-viewer-icon {
+  width: 72px;
+  height: auto;
+}
+
+/* Meta info */
+.postcard-meta {
+  margin-top: 32px;
+  padding-top: 16px;
+  border-top: 1px solid var(--color-gray-1);
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.postcard-meta-item {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--color-gray-4);
+  margin: 0;
+}
+
+.postcard-meta-item strong {
+  color: var(--color-gray-5);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .postcard-page {
+    padding: 16px 16px 32px;
+  }
+
+  .postcard-viewer-number {
+    font-size: 20px;
+  }
+
+  .postcard-meta {
+    flex-direction: column;
+    gap: 8px;
+  }
+}

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -338,14 +338,34 @@
   max-height: 90vh;
 }
 
+.modal-top-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
 .modal-postcard-number {
   font-family: var(--font-display);
   font-weight: 500;
   font-size: 24px;
   color: var(--color-white);
-  align-self: flex-start;
-  margin-bottom: 8px;
   padding-left: 4px;
+}
+
+.modal-close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  line-height: 0;
+  filter: brightness(0) invert(1);
+  transition: opacity 0.2s;
+}
+
+.modal-close-btn:hover {
+  opacity: 0.7;
 }
 
 /* Card flip container */
@@ -602,19 +622,6 @@
   text-decoration: underline;
 }
 
-.reply-address {
-  font-family: var(--font-body);
-  font-size: 16px;
-  line-height: 20px;
-  letter-spacing: 1.28px;
-  color: var(--color-black);
-  text-align: center;
-}
-
-.reply-address p {
-  margin: 0;
-}
-
 /* ==================== */
 /* Responsive            */
 /* ==================== */
@@ -694,14 +701,6 @@
 
   .modal-postcard-details {
     width: 95vw;
-  }
-
-  .reply-card {
-    width: 95vw;
-  }
-
-  .reply-postcard-example {
-    width: 100%;
   }
 }
 

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -2,6 +2,10 @@
 let currentPostcard = null;
 let isFlipped = false;
 
+// Cached DOM references (set in DOMContentLoaded)
+let postcardModal, replyModal, sendModal, cardContainer;
+let frontImg, backImg, numberEl;
+
 // ==================
 // Country Filter
 // ==================
@@ -55,15 +59,20 @@ function clearFilter() {
 }
 
 // ==================
-// Modal
+// Modal Helpers
+// ==================
+function setModalActive(modal, active) {
+  modal.classList.toggle('active', active);
+  if (active) {
+    const focusTarget = modal.querySelector('.reply-close, .send-modal-close, .modal-flip-btn');
+    if (focusTarget) focusTarget.focus();
+  }
+}
+
+// ==================
+// Postcard Modal
 // ==================
 function openModal(postcardElement) {
-  const modal = document.getElementById('postcard-modal');
-  const frontImg = modal.querySelector('.modal-front-img');
-  const backImg = modal.querySelector('.modal-back-img');
-  const numberEl = modal.querySelector('.modal-postcard-number');
-  const cardContainer = modal.querySelector('.modal-card-container');
-
   currentPostcard = postcardElement;
   isFlipped = false;
 
@@ -73,7 +82,7 @@ function openModal(postcardElement) {
   const backSrc = imgEl ? imgEl.dataset.back : '';
   const title = postcardElement.dataset.title || '';
   const number = postcardElement.dataset.number;
-  const slug = postcardElement.dataset.slug;
+  const permalink = postcardElement.dataset.permalink;
 
   if (!frontSrc) return;
 
@@ -88,44 +97,34 @@ function openModal(postcardElement) {
   cardContainer.classList.remove('flipped');
   updateModalButtons();
 
-  // Update URL
-  history.pushState({ postcardSlug: slug }, title, '#' + slug);
+  // Update URL to real postcard permalink
+  history.pushState({ postcardSlug: postcardElement.dataset.slug }, title, permalink);
 
   // Show modal
-  modal.classList.add('active');
+  postcardModal.classList.add('active');
   document.body.style.overflow = 'hidden';
-  modal.querySelector('.modal-flip-btn').focus();
+  postcardModal.querySelector('.modal-flip-btn').focus();
 }
 
 function closeModal(fromPopstate) {
-  const modal = document.getElementById('postcard-modal');
-  modal.classList.remove('active');
+  postcardModal.classList.remove('active');
   document.body.style.overflow = '';
   if (!fromPopstate) {
-    history.pushState(null, '', window.location.pathname);
+    history.pushState(null, '', '/posts.html');
   }
   currentPostcard = null;
   isFlipped = false;
 }
 
 function flipCard() {
-  const modal = document.getElementById('postcard-modal');
-  const cardContainer = modal.querySelector('.modal-card-container');
-
   isFlipped = !isFlipped;
-
-  if (isFlipped) {
-    cardContainer.classList.add('flipped');
-  } else {
-    cardContainer.classList.remove('flipped');
-  }
-
+  cardContainer.classList.toggle('flipped', isFlipped);
   updateModalButtons();
 }
 
 function updateModalButtons() {
-  const listenBtn = document.querySelector('.modal-listen-btn');
-  const readBtn = document.querySelector('.modal-read-btn');
+  const listenBtn = postcardModal.querySelector('.modal-listen-btn');
+  const readBtn = postcardModal.querySelector('.modal-read-btn');
 
   if (isFlipped) {
     listenBtn.style.display = 'flex';
@@ -144,95 +143,85 @@ function openModalBySlug(slug) {
 }
 
 // ==================
-// Reply Modal
-// ==================
-function openReplyModal() {
-  const replyModal = document.getElementById('reply-modal');
-  replyModal.classList.add('active');
-  replyModal.querySelector('.reply-close').focus();
-}
-
-function closeReplyModal() {
-  const replyModal = document.getElementById('reply-modal');
-  replyModal.classList.remove('active');
-}
-
-// ==================
-// Send Postcard Modal
-// ==================
-function openSendModal() {
-  const sendModal = document.getElementById('send-modal');
-  sendModal.classList.add('active');
-  sendModal.querySelector('.send-modal-close').focus();
-}
-
-function closeSendModal() {
-  const sendModal = document.getElementById('send-modal');
-  sendModal.classList.remove('active');
-}
-
-// ==================
 // Event Listeners
 // ==================
 document.addEventListener('DOMContentLoaded', function() {
+  // Cache DOM references
+  postcardModal = document.getElementById('postcard-modal');
+  replyModal = document.getElementById('reply-modal');
+  sendModal = document.getElementById('send-modal');
+  cardContainer = postcardModal.querySelector('.modal-card-container');
+  frontImg = postcardModal.querySelector('.modal-front-img');
+  backImg = postcardModal.querySelector('.modal-back-img');
+  numberEl = postcardModal.querySelector('.modal-postcard-number');
+
   initFilters();
 
+  // Delegated click handler for postcard grid
+  document.getElementById('postcard-grid').addEventListener('click', function(e) {
+    const item = e.target.closest('.postcard-item');
+    if (item) openModal(item);
+  });
+
   // Flip button
-  document.querySelector('.modal-flip-btn').addEventListener('click', function(e) {
+  postcardModal.querySelector('.modal-flip-btn').addEventListener('click', function(e) {
     e.stopPropagation();
     flipCard();
   });
 
-  // Close modal on backdrop click
-  document.querySelector('.modal-backdrop').addEventListener('click', closeModal);
+  // Close modal on backdrop or close button click
+  postcardModal.addEventListener('click', function(e) {
+    if (e.target === postcardModal || e.target.closest('.modal-backdrop')) {
+      closeModal();
+    }
+  });
+  postcardModal.querySelector('.modal-close-btn').addEventListener('click', function() { closeModal(); });
 
   // Arrow down → reply
-  document.querySelector('.modal-arrow-down').addEventListener('click', function(e) {
+  postcardModal.querySelector('.modal-arrow-down').addEventListener('click', function(e) {
     e.stopPropagation();
-    openReplyModal();
+    setModalActive(replyModal, true);
   });
 
   // Reply close
-  document.querySelector('.reply-close').addEventListener('click', function(e) {
+  replyModal.querySelector('.reply-close').addEventListener('click', function(e) {
     e.stopPropagation();
-    closeReplyModal();
+    setModalActive(replyModal, false);
   });
 
   // Reply overlay click → close reply
-  document.getElementById('reply-modal').addEventListener('click', function(e) {
+  replyModal.addEventListener('click', function(e) {
     if (e.target === this) {
-      closeReplyModal();
+      setModalActive(replyModal, false);
     }
   });
 
   // Send postcard button
   document.querySelector('.send-postcard-btn').addEventListener('click', function(e) {
     e.stopPropagation();
-    openSendModal();
+    setModalActive(sendModal, true);
   });
 
   // Send modal close
-  document.querySelector('.send-modal-close').addEventListener('click', function(e) {
+  sendModal.querySelector('.send-modal-close').addEventListener('click', function(e) {
     e.stopPropagation();
-    closeSendModal();
+    setModalActive(sendModal, false);
   });
 
   // Send modal overlay click → close
-  document.getElementById('send-modal').addEventListener('click', function(e) {
+  sendModal.addEventListener('click', function(e) {
     if (e.target === this) {
-      closeSendModal();
+      setModalActive(sendModal, false);
     }
   });
 
   // Escape key
   document.addEventListener('keydown', function(e) {
     if (e.key === 'Escape') {
-      const sendModal = document.getElementById('send-modal');
-      const replyModal = document.getElementById('reply-modal');
       if (sendModal.classList.contains('active')) {
-        closeSendModal();
+        setModalActive(sendModal, false);
       } else if (replyModal.classList.contains('active')) {
-        closeReplyModal();
+        setModalActive(replyModal, false);
       } else {
         closeModal();
       }
@@ -248,18 +237,18 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 
-  // Handle direct links
+  // Handle direct links (hash-based for backward compat)
   const hash = window.location.hash.substring(1);
   if (hash) {
     openModalBySlug(hash);
   }
 
   // Listen/Read buttons (no-op for now)
-  document.querySelector('.modal-listen-btn').addEventListener('click', function(e) {
+  postcardModal.querySelector('.modal-listen-btn').addEventListener('click', function(e) {
     e.stopPropagation();
   });
 
-  document.querySelector('.modal-read-btn').addEventListener('click', function(e) {
+  postcardModal.querySelector('.modal-read-btn').addEventListener('click', function(e) {
     e.stopPropagation();
   });
 });

--- a/posts.html
+++ b/posts.html
@@ -29,7 +29,6 @@ title: All Postcards
     {% assign post_index = 0 %}
     {% for post in site.posts %}
       {% assign post_index = post_index | plus: 1 %}
-      {% assign days_ago = "now" | date: "%s" | minus: post.date | date: "%s" %}
       {% assign is_new = false %}
       {% if post_index <= 3 %}
         {% assign is_new = true %}
@@ -37,13 +36,13 @@ title: All Postcards
       <div class="postcard-item"
            data-index="{{ post_index }}"
            data-slug="{{ post.slug }}"
+           data-permalink="{{ post.url | relative_url }}"
            data-title="{{ post.title | escape }}"
            data-date="{{ post.date | date: '%B %d, %Y' }}"
            data-country="{{ post.country }}"
            data-topic="{{ post.topic }}"
            data-content="{{ post.content | escape }}"
-           data-number="{{ post_index }}"
-           onclick="openModal(this)">
+           data-number="{{ post_index }}">
         {% if is_new %}
           <div class="new-badge">
             <span>New!</span>
@@ -71,105 +70,6 @@ title: All Postcards
   <span class="send-label">Send postcard</span>
 </button>
 
-<!-- Postcard Modal -->
-<div id="postcard-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-label="Postcard viewer">
-  <div class="modal-backdrop"></div>
-  <div class="modal-postcard-details">
-    <span class="modal-postcard-number"></span>
-    <div class="modal-postcard-wrapper">
-      <div class="modal-card-container">
-        <div class="modal-card-front">
-          <img class="modal-front-img" src="" alt="">
-        </div>
-        <div class="modal-card-back">
-          <img class="modal-back-img" src="" alt="">
-        </div>
-      </div>
-    </div>
-    <div class="modal-bottom-section">
-      <div class="modal-accessibility-btns">
-        <button class="modal-action-btn modal-listen-btn" style="display:none">
-          <img src="{{ '/assets/icons/speaker.svg' | relative_url }}" alt="Listen" class="modal-action-icon">
-        </button>
-        <button class="modal-action-btn modal-read-btn" style="display:none">
-          <img src="{{ '/assets/icons/transcript.svg' | relative_url }}" alt="Read" class="modal-action-icon">
-        </button>
-      </div>
-      <button class="modal-action-btn modal-flip-btn">
-        <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="modal-action-icon">
-      </button>
-    </div>
-    <button class="modal-arrow-down" aria-label="Send a reply">
-      <svg width="32" height="16" viewBox="0 0 32 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M4 4L16 12L28 4" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-      </svg>
-    </button>
-  </div>
-</div>
-
-<!-- Reply Info Modal -->
-<div id="reply-modal" class="reply-overlay" role="dialog" aria-modal="true" aria-label="Send a reply">
-  <div class="reply-card">
-    <button class="reply-close" aria-label="Close">
-      <img src="{{ '/assets/icons/close.svg' | relative_url }}" alt="Close" width="20" height="20">
-    </button>
-    <div class="reply-content">
-      <h2 class="reply-title">To send a reply:</h2>
-      <p class="reply-instruction">Write the same number displayed above the postcard on the top left side of your reply postcard.</p>
-      <div class="reply-postcard-example">
-        <div class="reply-example-number">#123</div>
-        <div class="reply-example-body">
-          <div class="reply-example-left">
-            <p class="reply-example-meta">City, Date</p>
-            <p class="reply-example-heading">Your message</p>
-            <p class="reply-example-text">Write your story, thoughts, or reply here...</p>
-            <p class="reply-example-sign">/Your name (optional)</p>
-          </div>
-          <div class="reply-example-divider"></div>
-          <div class="reply-example-right">
-            <div class="reply-example-stamp"></div>
-            <div class="reply-example-address">
-              <p>{{ site.mailing_address.name }}</p>
-              <p>{{ site.mailing_address.street }}</p>
-              <p>{{ site.mailing_address.postal }}</p>
-              <p>{{ site.mailing_address.country }}</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<!-- Send Postcard Modal -->
-<div id="send-modal" class="reply-overlay" role="dialog" aria-modal="true" aria-label="Send a postcard">
-  <div class="reply-card">
-    <button class="send-modal-close" aria-label="Close">
-      <img src="{{ '/assets/icons/close.svg' | relative_url }}" alt="Close" width="20" height="20">
-    </button>
-    <div class="reply-content">
-      <h2 class="reply-title">Send a postcard</h2>
-      <p class="reply-instruction">Write your story, thoughts, or message on a postcard and post it to:</p>
-      <div class="reply-postcard-example">
-        <div class="reply-example-body">
-          <div class="reply-example-left">
-            <p class="reply-example-meta">City, Date</p>
-            <p class="reply-example-heading">Your message</p>
-            <p class="reply-example-text">Write your story, thoughts, or message here...</p>
-            <p class="reply-example-sign">/Your name (optional)</p>
-          </div>
-          <div class="reply-example-divider"></div>
-          <div class="reply-example-right">
-            <div class="reply-example-stamp"></div>
-            <div class="reply-example-address">
-              <p>{{ site.mailing_address.name }}</p>
-              <p>{{ site.mailing_address.street }}</p>
-              <p>{{ site.mailing_address.postal }}</p>
-              <p>{{ site.mailing_address.country }}</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+{% include modals/postcard.html %}
+{% include modals/reply.html %}
+{% include modals/send.html %}


### PR DESCRIPTION
## Summary
- Extract modal markup from `posts.html` into `_includes/modals/` (postcard, reply, send) and clean up dead code (unused CSS rules, Liquid variables)
- Add standalone postcard pages at `/postcards/:slug/` for SEO and link sharing, with SPA-like URL updates when opening postcards from the grid
- Improve JS with cached DOM references, delegated click handler, shared modal helper, close button on postcard modal, and backdrop click fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)