### PR TITLE
feat: improve sidebar filters with multi-select and full country names

### DIFF
--- a/_data/countries.yml
+++ b/_data/countries.yml
@@ -1,0 +1,70 @@
+- code: AR
+  name: Argentina
+- code: AU
+  name: Australia
+- code: AT
+  name: Austria
+- code: BR
+  name: Brazil
+- code: CA
+  name: Canada
+- code: CU
+  name: Cuba
+- code: CZ
+  name: Czech Republic
+- code: DK
+  name: Denmark
+- code: EG
+  name: Egypt
+- code: FI
+  name: Finland
+- code: FR
+  name: France
+- code: DE
+  name: Germany
+- code: GR
+  name: Greece
+- code: IS
+  name: Iceland
+- code: IN
+  name: India
+- code: IE
+  name: Ireland
+- code: IT
+  name: Italy
+- code: JP
+  name: Japan
+- code: KE
+  name: Kenya
+- code: MX
+  name: Mexico
+- code: MA
+  name: Morocco
+- code: NL
+  name: Netherlands
+- code: NZ
+  name: New Zealand
+- code: PT
+  name: Portugal
+- code: SG
+  name: Singapore
+- code: ZA
+  name: South Africa
+- code: KR
+  name: South Korea
+- code: ES
+  name: Spain
+- code: SE
+  name: Sweden
+- code: CH
+  name: Switzerland
+- code: TH
+  name: Thailand
+- code: TR
+  name: Turkey
+- code: AE
+  name: United Arab Emirates
+- code: GB
+  name: United Kingdom
+- code: US
+  name: United States

--- a/_data/countries.yml
+++ b/_data/countries.yml
@@ -44,6 +44,8 @@
   name: Netherlands
 - code: NZ
   name: New Zealand
+- code: "NO"
+  name: Norway
 - code: PT
   name: Portugal
 - code: SG

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -91,7 +91,7 @@
   flex-direction: column;
   gap: 4px;
   padding: 0 0 8px 8px;
-  max-height: calc(100vh - 380px);
+  max-height: var(--filter-list-max-height, calc(100vh - 380px));
   overflow-y: auto;
 }
 

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -9,7 +9,7 @@
 /* Sidebar */
 .sidebar {
   flex-shrink: 0;
-  width: 155px;
+  width: 200px;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -25,6 +25,30 @@
   flex-direction: column;
   gap: 8px;
   padding: 32px 0;
+}
+
+.filter-clear {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px 0;
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 16px;
+  color: var(--color-gray-5);
+  transition: color 0.2s;
+}
+
+.filter-clear:hover {
+  color: var(--color-lavender);
+}
+
+.filter-clear.active {
+  color: var(--color-lavender);
+  font-weight: 700;
 }
 
 .filter-name {
@@ -50,7 +74,8 @@
   transform: rotate(90deg);
 }
 
-.filter-name.expanded .filter-label {
+.filter-name.has-selection {
+  color: var(--color-lavender);
   font-weight: 700;
 }
 
@@ -66,7 +91,7 @@
   flex-direction: column;
   gap: 4px;
   padding: 0 0 8px 8px;
-  max-height: 400px;
+  max-height: calc(100vh - 380px);
   overflow-y: auto;
 }
 
@@ -95,7 +120,6 @@
 .filter-option.active {
   background: var(--color-lavender-bright);
   color: var(--color-lavender-dark);
-  font-weight: 700;
 }
 
 /* Send postcard button — fixed bottom-left */

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -27,21 +27,44 @@ function initFilters() {
   });
 
   const filterOptions = document.querySelectorAll('.filter-option');
+  const clearBtn = document.querySelector('.filter-clear');
+  const countryBtn = document.querySelector('.filter-name[data-filter="country"]');
+
+  function applyCountryFilter() {
+    const activeCountries = Array.from(filterOptions)
+      .filter(o => o.classList.contains('active'))
+      .map(o => o.dataset.country);
+
+    if (activeCountries.length === 0) {
+      clearBtn.classList.add('active');
+      countryBtn.classList.remove('has-selection');
+      clearFilter();
+    } else {
+      clearBtn.classList.remove('active');
+      countryBtn.classList.add('has-selection');
+      const items = document.querySelectorAll('.postcard-item');
+      items.forEach(item => {
+        if (activeCountries.includes(item.dataset.country)) {
+          item.classList.remove('filtered-out');
+        } else {
+          item.classList.add('filtered-out');
+        }
+      });
+    }
+  }
+
   filterOptions.forEach(option => {
     option.addEventListener('click', () => {
-      const country = option.dataset.country;
-      const wasActive = option.classList.contains('active');
-
-      // Deselect all
-      filterOptions.forEach(o => o.classList.remove('active'));
-
-      if (!wasActive) {
-        option.classList.add('active');
-        filterByCountry(country);
-      } else {
-        clearFilter();
-      }
+      option.classList.toggle('active');
+      applyCountryFilter();
     });
+  });
+
+  clearBtn.addEventListener('click', () => {
+    filterOptions.forEach(o => o.classList.remove('active'));
+    clearBtn.classList.add('active');
+    countryBtn.classList.remove('has-selection');
+    clearFilter();
   });
 }
 

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -8,6 +8,7 @@ let currentHoveredItem = null;
 // Cached DOM references (set in DOMContentLoaded)
 let postcardModal, replyModal, sendModal, cardContainer;
 let frontImg, backImg, numberEl;
+let postcardItems;
 
 // ==================
 // Country Filter
@@ -42,8 +43,7 @@ function initFilters() {
     } else {
       clearBtn.classList.remove('active');
       countryBtn.classList.add('has-selection');
-      const items = document.querySelectorAll('.postcard-item');
-      items.forEach(item => {
+      postcardItems.forEach(item => {
         if (activeCountries.includes(item.dataset.country)) {
           item.classList.remove('filtered-out');
         } else {
@@ -453,6 +453,8 @@ document.addEventListener('DOMContentLoaded', function() {
   backImg = postcardModal.querySelector('.modal-back-img');
   numberEl = postcardModal.querySelector('.modal-postcard-number');
 
+  postcardItems = document.querySelectorAll('.postcard-item');
+
   initFilters();
 
   // Delegated click handler for postcard grid
@@ -553,7 +555,6 @@ document.addEventListener('DOMContentLoaded', function() {
   // ==================
   // Scroll Inertia Effect
   // ==================
-  const postcardItems = document.querySelectorAll('.postcard-item');
 
   // Each card tracks its own offset that lags behind scroll
   var cardOffsets = new Array(postcardItems.length);

--- a/posts.html
+++ b/posts.html
@@ -18,7 +18,7 @@ title: All Postcards
         {% assign used_codes = posts_with_country | map: "country" | uniq %}
         {% for entry in site.data.countries %}
           {% if used_codes contains entry.code %}
-            <button class="filter-option" data-country="{{ entry.code }}">{{ entry.name }}</button>
+            <button class="filter-option" role="option" data-country="{{ entry.code }}">{{ entry.name }}</button>
           {% endif %}
         {% endfor %}
       </div>

--- a/posts.html
+++ b/posts.html
@@ -6,6 +6,7 @@ title: All Postcards
 <div class="landing-layout">
   <aside class="sidebar">
     <div class="filters">
+      <button class="filter-clear active">All postcards</button>
       <button class="filter-name" data-filter="country" aria-expanded="false" aria-controls="country-options">
         <span class="filter-label">Country</span>
         <svg class="filter-arrow" width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -14,9 +15,11 @@ title: All Postcards
       </button>
       <div class="filter-options" id="country-options" role="listbox">
         {% assign posts_with_country = site.posts | where_exp: "post", "post.country" %}
-        {% assign countries = posts_with_country | map: "country" | uniq | sort %}
-        {% for country in countries %}
-          <button class="filter-option" data-country="{{ country }}">{{ country }}</button>
+        {% assign used_codes = posts_with_country | map: "country" | uniq %}
+        {% for entry in site.data.countries %}
+          {% if used_codes contains entry.code %}
+            <button class="filter-option" data-country="{{ entry.code }}">{{ entry.name }}</button>
+          {% endif %}
         {% endfor %}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add "All postcards" clear-filter button above Country filter
- Enable multi-select for country filtering (toggle individual countries on/off)
- Display full English country names sorted alphabetically (via `_data/countries.yml`)
- Constrain filter list height to viewport-relative max so it stops above the fixed "Send postcard" button
- Unify active/selected styling: top-level items (All postcards / Country) get bold purple text, country options get purple background pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)