### PR TITLE
feat: implement Read button with transcript overlay

### DIFF
--- a/_includes/modals/postcard.html
+++ b/_includes/modals/postcard.html
@@ -16,7 +16,7 @@
         <div class="modal-card-back">
           <img class="modal-back-img" src="" alt="">
           <div class="modal-read-overlay">
-            <p class="modal-read-text"></p>
+            <div class="modal-read-text"></div>
           </div>
         </div>
       </div>

--- a/_includes/modals/postcard.html
+++ b/_includes/modals/postcard.html
@@ -16,6 +16,9 @@
         <div class="modal-card-back">
           <img class="modal-back-img" src="" alt="">
         </div>
+        <div class="modal-read-overlay">
+          <p class="modal-read-text"></p>
+        </div>
       </div>
     </div>
     <div class="modal-bottom-section">

--- a/_includes/modals/postcard.html
+++ b/_includes/modals/postcard.html
@@ -15,9 +15,9 @@
         </div>
         <div class="modal-card-back">
           <img class="modal-back-img" src="" alt="">
-        </div>
-        <div class="modal-read-overlay">
-          <p class="modal-read-text"></p>
+          <div class="modal-read-overlay">
+            <p class="modal-read-text"></p>
+          </div>
         </div>
       </div>
     </div>

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -510,7 +510,11 @@
 /* Read transcript overlay */
 .modal-read-overlay {
   position: absolute;
-  inset: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: var(--visible-img-width, 100%);
+  height: var(--visible-img-height, 100%);
   background: rgba(255, 255, 255, 0.92);
   display: flex;
   align-items: center;
@@ -520,6 +524,7 @@
   pointer-events: none;
   transition: opacity 0.3s ease;
   border-radius: 2px;
+  overflow-y: auto;
 }
 
 .modal-read-overlay.active {

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -507,6 +507,41 @@
   50% { opacity: 0.6; }
 }
 
+/* Read transcript overlay */
+.modal-read-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  border-radius: 2px;
+}
+
+.modal-read-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal-read-text {
+  font-family: var(--font-body);
+  font-size: 18px;
+  line-height: 1.7;
+  color: var(--color-gray-5);
+  text-align: center;
+  max-width: 480px;
+  margin: 0;
+}
+
+/* Read button active state */
+.modal-read-btn.reading .modal-action-icon {
+  filter: drop-shadow(0 0 6px rgba(195, 177, 225, 0.7));
+}
+
 /* Down arrow to reply */
 .modal-arrow-down {
   background: rgba(40, 36, 58, 0.5);

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -300,6 +300,9 @@ function openModal(postcardElement, skipAnimation) {
 }
 
 function closeModal(fromPopstate) {
+  // Close read overlay
+  closeReadOverlay();
+
   // Stop audio playback
   stopAudio();
 
@@ -425,6 +428,7 @@ function closeModal(fromPopstate) {
 }
 
 function flipCard() {
+  closeReadOverlay();
   isFlipped = !isFlipped;
   cardContainer.classList.toggle('flipped', isFlipped);
   updateModalButtons();
@@ -438,12 +442,9 @@ function updateModalButtons() {
   const hasAudio = currentPostcard && currentPostcard.dataset.audio;
   listenBtn.style.display = hasAudio ? 'flex' : 'none';
 
-  // Read button: visible only when flipped
-  if (isFlipped) {
-    readBtn.style.display = 'flex';
-  } else {
-    readBtn.style.display = 'none';
-  }
+  // Read button: visible only when flipped and postcard has content
+  const hasContent = currentPostcard && currentPostcard.dataset.content;
+  readBtn.style.display = (isFlipped && hasContent) ? 'flex' : 'none';
 }
 
 function handleAudioEnd() {
@@ -507,6 +508,32 @@ function toggleAudio() {
   } else {
     startAudio(currentPostcard.dataset.audio);
   }
+}
+
+function toggleReadOverlay() {
+  var overlay = postcardModal.querySelector('.modal-read-overlay');
+  var readBtn = postcardModal.querySelector('.modal-read-btn');
+  var isActive = overlay.classList.contains('active');
+
+  if (isActive) {
+    overlay.classList.remove('active');
+    readBtn.classList.remove('reading');
+    readBtn.setAttribute('aria-label', 'Read transcript');
+  } else {
+    if (currentPostcard && currentPostcard.dataset.content) {
+      postcardModal.querySelector('.modal-read-text').innerHTML = currentPostcard.dataset.content;
+    }
+    overlay.classList.add('active');
+    readBtn.classList.add('reading');
+    readBtn.setAttribute('aria-label', 'Hide transcript');
+  }
+}
+
+function closeReadOverlay() {
+  var overlay = postcardModal.querySelector('.modal-read-overlay');
+  var readBtn = postcardModal.querySelector('.modal-read-btn');
+  overlay.classList.remove('active');
+  readBtn.classList.remove('reading');
 }
 
 function updateListenButtonState() {
@@ -636,9 +663,10 @@ document.addEventListener('DOMContentLoaded', function() {
     toggleAudio();
   });
 
-  // Read button (no-op for now)
+  // Read button — toggle transcript overlay
   postcardModal.querySelector('.modal-read-btn').addEventListener('click', function(e) {
     e.stopPropagation();
+    toggleReadOverlay();
   });
 
   // ==================

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -144,8 +144,13 @@ function openModal(postcardElement, skipAnimation) {
   if (postcardModal._resizeHandler) {
     window.removeEventListener('resize', postcardModal._resizeHandler);
   }
-  postcardModal._resizeHandler = updateImgWidth;
-  window.addEventListener('resize', updateImgWidth);
+  postcardModal._resizeHandler = function() {
+    updateImgWidth();
+    if (postcardModal.querySelector('.modal-read-overlay').classList.contains('active')) {
+      updateReadOverlaySize();
+    }
+  };
+  window.addEventListener('resize', postcardModal._resizeHandler);
   backImg.src = backSrc || '';
   backImg.alt = backSrc ? title + ' - Back' : '';
   numberEl.textContent = '#' + number;
@@ -513,7 +518,14 @@ function toggleAudio() {
 function updateReadOverlaySize() {
   var overlay = postcardModal.querySelector('.modal-read-overlay');
   var img = backImg;
-  if (!img.naturalWidth || !img.naturalHeight) return;
+  if (!img.naturalWidth || !img.naturalHeight) {
+    // Retry once when image loads
+    img.addEventListener('load', function onLoad() {
+      img.removeEventListener('load', onLoad);
+      if (overlay.classList.contains('active')) updateReadOverlaySize();
+    });
+    return;
+  }
   var imgRect = img.getBoundingClientRect();
   var natRatio = img.naturalWidth / img.naturalHeight;
   var elemRatio = imgRect.width / imgRect.height;

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -534,6 +534,7 @@ function closeReadOverlay() {
   var readBtn = postcardModal.querySelector('.modal-read-btn');
   overlay.classList.remove('active');
   readBtn.classList.remove('reading');
+  readBtn.setAttribute('aria-label', 'Read transcript');
 }
 
 function updateListenButtonState() {

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -510,6 +510,25 @@ function toggleAudio() {
   }
 }
 
+function updateReadOverlaySize() {
+  var overlay = postcardModal.querySelector('.modal-read-overlay');
+  var img = backImg;
+  if (!img.naturalWidth || !img.naturalHeight) return;
+  var imgRect = img.getBoundingClientRect();
+  var natRatio = img.naturalWidth / img.naturalHeight;
+  var elemRatio = imgRect.width / imgRect.height;
+  var visW, visH;
+  if (elemRatio > natRatio) {
+    visH = imgRect.height;
+    visW = imgRect.height * natRatio;
+  } else {
+    visW = imgRect.width;
+    visH = imgRect.width / natRatio;
+  }
+  overlay.style.setProperty('--visible-img-width', visW + 'px');
+  overlay.style.setProperty('--visible-img-height', visH + 'px');
+}
+
 function toggleReadOverlay() {
   var overlay = postcardModal.querySelector('.modal-read-overlay');
   var readBtn = postcardModal.querySelector('.modal-read-btn');
@@ -523,6 +542,7 @@ function toggleReadOverlay() {
     if (currentPostcard && currentPostcard.dataset.content) {
       postcardModal.querySelector('.modal-read-text').innerHTML = currentPostcard.dataset.content;
     }
+    updateReadOverlaySize();
     overlay.classList.add('active');
     readBtn.classList.add('reading');
     readBtn.setAttribute('aria-label', 'Hide transcript');


### PR DESCRIPTION
## Summary
- The **Read** button on the postcard modal now displays a white semi-transparent overlay with the postcard's transcript text over the back of the card
- Read button only appears when viewing the back (flipped) side of a postcard
- Clicking Read toggles the overlay on/off; flipping the card or closing the modal auto-dismisses it
- Transcript content is sourced from the existing post body data (`data-content`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)