### PR TITLE
feat: add social media links to footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,12 @@ mailing_address:
   postal: "123 32 City"
   country: "Country"
 
+# Social links (shown in footer)
+social:
+  instagram: "https://www.instagram.com/queerpostbox"
+  tiktok: "https://www.tiktok.com/@queerpostbox"
+  email: "hello@queerpostbox.com"
+
 # Build settings
 # theme: jekyll-theme-minimal
 # theme: minima

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,28 @@
+<footer class="site-footer">
+  <div class="footer-social">
+    {% if site.social.instagram %}
+      <a href="{{ site.social.instagram }}" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="social-icon" aria-hidden="true">
+          <rect x="2" y="2" width="20" height="20" rx="5" stroke="currentColor" stroke-width="1.5"/>
+          <circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="1.5"/>
+          <circle cx="17.5" cy="6.5" r="1" fill="currentColor"/>
+        </svg>
+      </a>
+    {% endif %}
+    {% if site.social.tiktok %}
+      <a href="{{ site.social.tiktok }}" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="TikTok">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="social-icon" aria-hidden="true">
+          <path d="M16.6 5.82C15.9165 5.03962 15.5397 4.03743 15.54 3H12.45V15.4C12.4262 16.071 12.1429 16.7066 11.6598 17.1729C11.1767 17.6393 10.5315 17.8999 9.86 17.9C8.44 17.9 7.26 16.74 7.26 15.3C7.26 13.58 8.92 12.29 10.63 12.82V9.66C7.18 9.2 4.16 11.88 4.16 15.3C4.16 18.63 6.92 21 9.85 21C12.99 21 15.54 18.45 15.54 15.3V9.01C16.7931 9.90985 18.2974 10.3926 19.84 10.39V7.3C19.84 7.3 17.96 7.39 16.6 5.82Z" fill="currentColor"/>
+        </svg>
+      </a>
+    {% endif %}
+    {% if site.social.email %}
+      <a href="mailto:{{ site.social.email }}" class="social-link" aria-label="Email">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="social-icon" aria-hidden="true">
+          <rect x="2" y="4" width="20" height="16" rx="2" stroke="currentColor" stroke-width="1.5"/>
+          <path d="M2 7L10.8906 13.2604C11.5624 13.7083 12.4376 13.7083 13.1094 13.2604L22 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </a>
+    {% endif %}
+  </div>
+</footer>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -115,9 +115,47 @@ body {
   width: 100%;
 }
 
+/* Footer */
+.site-footer {
+  padding: 40px 25px;
+  display: flex;
+  justify-content: center;
+}
+
+.footer-social {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.social-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  color: var(--color-gray-4);
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.social-link:hover {
+  color: var(--color-lavender);
+  background-color: var(--color-light-2);
+}
+
+.social-icon {
+  width: 24px;
+  height: 24px;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .site-header {
     padding: 16px;
+  }
+
+  .site-footer {
+    padding: 32px 16px;
   }
 }


### PR DESCRIPTION
## Summary
- Add Instagram, TikTok, and email social links to the site footer with inline SVG icons
- Social URLs are configurable via `_config.yml` under a new `social` key
- Footer styled with hover effects using the existing design tokens (lavender accent on hover)
- Links conditionally render only when configured, with proper `aria-label` attributes for accessibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)