### PR TITLE
feat: add footer navigation links and privacy page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,7 @@ mailing_address:
 social:
   instagram: "https://www.instagram.com/queerpostbox"
   tiktok: "https://www.tiktok.com/@queerpostbox"
+  youtube: "https://www.youtube.com/@queerpostbox"
   email: "hello@queerpostbox.com"
 
 # Build settings

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,12 @@
 <footer class="site-footer">
+  <nav class="footer-nav" aria-label="Footer navigation">
+    <a href="{{ '/about/' | relative_url }}" class="footer-link">About</a>
+    <a href="{{ '/privacy/' | relative_url }}" class="footer-link">Privacy</a>
+    {% if site.social.email %}
+      <a href="mailto:{{ site.social.email }}" class="footer-link">Contact</a>
+    {% endif %}
+  </nav>
+
   <div class="footer-social">
     {% if site.social.instagram %}
       <a href="{{ site.social.instagram }}" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
@@ -13,6 +21,14 @@
       <a href="{{ site.social.tiktok }}" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="TikTok">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="social-icon" aria-hidden="true">
           <path d="M16.6 5.82C15.9165 5.03962 15.5397 4.03743 15.54 3H12.45V15.4C12.4262 16.071 12.1429 16.7066 11.6598 17.1729C11.1767 17.6393 10.5315 17.8999 9.86 17.9C8.44 17.9 7.26 16.74 7.26 15.3C7.26 13.58 8.92 12.29 10.63 12.82V9.66C7.18 9.2 4.16 11.88 4.16 15.3C4.16 18.63 6.92 21 9.85 21C12.99 21 15.54 18.45 15.54 15.3V9.01C16.7931 9.90985 18.2974 10.3926 19.84 10.39V7.3C19.84 7.3 17.96 7.39 16.6 5.82Z" fill="currentColor"/>
+        </svg>
+      </a>
+    {% endif %}
+    {% if site.social.youtube %}
+      <a href="{{ site.social.youtube }}" class="social-link" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="social-icon" aria-hidden="true">
+          <path d="M22.54 6.42C22.4212 5.94541 22.1793 5.51057 21.8387 5.15941C21.498 4.80824 21.0708 4.55318 20.6 4.42C18.88 4 12 4 12 4C12 4 5.12 4 3.4 4.46C2.92925 4.59318 2.50198 4.84824 2.16135 5.19941C1.82072 5.55057 1.57879 5.98541 1.46 6.46C1.14521 8.20556 0.991235 9.97631 1 11.75C0.988802 13.537 1.14278 15.3213 1.46 17.08C1.59096 17.5398 1.83831 17.9581 2.17814 18.2945C2.51798 18.6308 2.93882 18.8738 3.4 19C5.12 19.46 12 19.46 12 19.46C12 19.46 18.88 19.46 20.6 19C21.0708 18.8668 21.498 18.6118 21.8387 18.2606C22.1793 17.9094 22.4212 17.4746 22.54 17C22.8524 15.2676 23.0063 13.5103 23 11.75C23.0112 9.96295 22.8572 8.1787 22.54 6.42Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M9.75 15.02L15.5 11.75L9.75 8.48V15.02Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </a>
     {% endif %}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -122,6 +122,8 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 20px;
+  border-top: 1px solid var(--color-gray-1);
+  margin-top: 24px;
 }
 
 .footer-nav {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -119,7 +119,28 @@ body {
 .site-footer {
   padding: 40px 25px;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.footer-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+.footer-link {
+  font-family: var(--font-body);
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  color: var(--color-gray-3);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footer-link:hover {
+  color: var(--color-lavender);
 }
 
 .footer-social {

--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Privacy Policy
+permalink: /privacy/
+---
+
+# Privacy Policy
+
+**Last updated:** {{ site.time | date: "%B %d, %Y" }}
+
+## What we collect
+
+Queer Postbox does not use cookies, tracking scripts, or analytics. We do not collect personal data from visitors browsing this site.
+
+## Postcards
+
+Postcards displayed on this site are submitted voluntarily by contributors. By submitting a postcard, you agree to have it published on this website.
+
+## Third-party services
+
+This site is hosted on GitHub Pages. GitHub may collect technical information such as IP addresses in server logs. See [GitHub's Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement) for details.
+
+## Contact
+
+If you have questions about this policy, reach out at [{{ site.social.email }}](mailto:{{ site.social.email }}).

--- a/privacy.md
+++ b/privacy.md
@@ -2,11 +2,12 @@
 layout: default
 title: Privacy Policy
 permalink: /privacy/
+last_updated: 2026-04-04
 ---
 
 # Privacy Policy
 
-**Last updated:** {{ site.time | date: "%B %d, %Y" }}
+**Last updated:** {{ page.last_updated | date: "%B %d, %Y" }}
 
 ## What we collect
 


### PR DESCRIPTION
## Summary
- Add navigation links (About, Privacy, Contact) to the footer above existing social icons
- Create a privacy policy page at `/privacy/`
- Add YouTube to the social links configuration
- Style footer nav links with hover effects matching the site's design system

🤖 Generated with [Claude Code](https://claude.com/claude-code)