### PR TITLE
feat: improve post page with country name, transcript, and layout fix

### DIFF
--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -33,7 +33,9 @@ layout: default
 
   <div class="postcard-main">
     <div class="postcard-viewer">
-      <span class="postcard-viewer-number">#{{ post_number }}</span>
+      <div class="postcard-viewer-top-row">
+        <span class="postcard-viewer-number">#{{ post_number }}</span>
+      </div>
 
       <div class="postcard-viewer-wrapper">
         <div class="postcard-viewer-container" id="card-container">

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -103,7 +103,10 @@ layout: default
       if (frontImg.complete) updateViewerSize();
       else frontImg.addEventListener('load', updateViewerSize);
     }
-    window.addEventListener('resize', updateViewerSize);
+    window.addEventListener('resize', function() {
+      updateViewerSize();
+      if (readOverlay && readOverlay.classList.contains('active')) updateReadOverlaySize();
+    });
 
     flipBtn.addEventListener('click', function() {
       isFlipped = !isFlipped;
@@ -119,12 +122,19 @@ layout: default
       });
     }
 
+    var backImg = document.querySelector('.postcard-viewer-back .postcard-viewer-img');
+
     function updateReadOverlaySize() {
-      if (!readOverlay) return;
-      var img = document.querySelector('.postcard-viewer-back .postcard-viewer-img');
-      if (!img || !img.naturalWidth || !img.naturalHeight) return;
-      var rect = img.getBoundingClientRect();
-      var natRatio = img.naturalWidth / img.naturalHeight;
+      if (!readOverlay || !backImg) return;
+      if (!backImg.naturalWidth || !backImg.naturalHeight) {
+        backImg.addEventListener('load', function onLoad() {
+          backImg.removeEventListener('load', onLoad);
+          if (readOverlay.classList.contains('active')) updateReadOverlaySize();
+        });
+        return;
+      }
+      var rect = backImg.getBoundingClientRect();
+      var natRatio = backImg.naturalWidth / backImg.naturalHeight;
       var elemRatio = rect.width / rect.height;
       var visW, visH;
       if (elemRatio > natRatio) {

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -59,9 +59,11 @@ layout: default
 
       <div class="postcard-viewer-actions">
         <div class="postcard-viewer-accessibility">
+          {% if page.audio %}
           <button class="postcard-viewer-btn postcard-listen-btn" style="display:none">
             <img src="{{ '/assets/icons/speaker.svg' | relative_url }}" alt="Listen" class="postcard-viewer-icon">
           </button>
+          {% endif %}
           {% if content != '' %}
           <button class="postcard-viewer-btn postcard-read-btn" style="display:none" aria-label="Read transcript">
             <img src="{{ '/assets/icons/transcript.svg' | relative_url }}" alt="Read" class="postcard-viewer-icon">

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -16,67 +16,109 @@ layout: default
 {% assign country_name = country_data.name | default: page.country %}
 
 <div class="postcard-page">
-  <a href="{{ '/posts.html' | relative_url }}" class="postcard-back-link">
-    <svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M6 1L1 6L6 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-    All postcards
-  </a>
+  <aside class="postcard-sidebar">
+    <a href="{{ '/posts.html' | relative_url }}" class="postcard-back-link">All postcards</a>
 
-  <div class="postcard-viewer">
-    <span class="postcard-viewer-number">#{{ post_number }}</span>
+    <div class="postcard-meta">
+      <p class="postcard-meta-item"><strong>Country</strong><span>{{ country_name }}</span></p>
+      <p class="postcard-meta-item"><strong>Topic</strong><span>{{ page.topic }}</span></p>
+      <p class="postcard-meta-item"><strong>Date</strong><span>{{ page.date | date: "%B %d, %Y" }}</span></p>
+    </div>
+  </aside>
 
-    <div class="postcard-viewer-wrapper">
-      <div class="postcard-viewer-container" id="card-container">
-        <div class="postcard-viewer-front">
-          {% if page.image-front %}
-            <img src="{{ page.image-front | relative_url }}" alt="{{ page.title }} - Front" class="postcard-viewer-img">
-          {% endif %}
-        </div>
-        <div class="postcard-viewer-back">
-          {% if page.image-back %}
-            <img src="{{ page.image-back | relative_url }}" alt="{{ page.title }} - Back" class="postcard-viewer-img">
-          {% endif %}
+  <div class="postcard-main">
+    <div class="postcard-viewer">
+      <span class="postcard-viewer-number">#{{ post_number }}</span>
+
+      <div class="postcard-viewer-wrapper">
+        <div class="postcard-viewer-container" id="card-container">
+          <div class="postcard-viewer-front">
+            {% if page.image-front %}
+              <img src="{{ page.image-front | relative_url }}" alt="{{ page.title }} - Front" class="postcard-viewer-img">
+            {% endif %}
+          </div>
+          <div class="postcard-viewer-back">
+            {% if page.image-back %}
+              <img src="{{ page.image-back | relative_url }}" alt="{{ page.title }} - Back" class="postcard-viewer-img">
+            {% endif %}
+            {% if content != '' %}
+            <div class="postcard-read-overlay" id="read-overlay">
+              <div class="postcard-read-text">{{ content }}</div>
+            </div>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="postcard-viewer-actions">
-      <div class="postcard-viewer-accessibility">
-        <button class="postcard-viewer-btn postcard-listen-btn" style="display:none">
-          <img src="{{ '/assets/icons/speaker.svg' | relative_url }}" alt="Listen" class="postcard-viewer-icon">
+      <div class="postcard-viewer-actions">
+        <div class="postcard-viewer-accessibility">
+          <button class="postcard-viewer-btn postcard-listen-btn" style="display:none">
+            <img src="{{ '/assets/icons/speaker.svg' | relative_url }}" alt="Listen" class="postcard-viewer-icon">
+          </button>
+          {% if content != '' %}
+          <button class="postcard-viewer-btn postcard-read-btn" style="display:none" aria-label="Read transcript">
+            <img src="{{ '/assets/icons/transcript.svg' | relative_url }}" alt="Read" class="postcard-viewer-icon">
+          </button>
+          {% endif %}
+        </div>
+        <button class="postcard-viewer-btn postcard-flip-btn" id="flip-btn">
+          <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="postcard-viewer-icon">
         </button>
       </div>
-      <button class="postcard-viewer-btn postcard-flip-btn" id="flip-btn">
-        <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="postcard-viewer-icon">
-      </button>
     </div>
-  </div>
-
-  {% if content != '' %}
-  <div class="postcard-transcript">
-    {{ content }}
-  </div>
-  {% endif %}
-
-  <div class="postcard-meta">
-    <p class="postcard-meta-item"><strong>Country:</strong> {{ country_name }}</p>
-    <p class="postcard-meta-item"><strong>Topic:</strong> {{ page.topic }}</p>
-    <p class="postcard-meta-item"><strong>Date:</strong> {{ page.date | date: "%B %d, %Y" }}</p>
   </div>
 </div>
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    const container = document.getElementById('card-container');
-    const flipBtn = document.getElementById('flip-btn');
-    const listenBtn = document.querySelector('.postcard-listen-btn');
-    let isFlipped = false;
+    var container = document.getElementById('card-container');
+    var flipBtn = document.getElementById('flip-btn');
+    var listenBtn = document.querySelector('.postcard-listen-btn');
+    var readBtn = document.querySelector('.postcard-read-btn');
+    var readOverlay = document.getElementById('read-overlay');
+    var isFlipped = false;
 
     flipBtn.addEventListener('click', function() {
       isFlipped = !isFlipped;
       container.classList.toggle('flipped', isFlipped);
       listenBtn.style.display = isFlipped ? 'flex' : 'none';
+      if (readBtn) readBtn.style.display = isFlipped ? 'flex' : 'none';
+      if (!isFlipped) closeReadOverlay();
     });
+
+    if (readBtn && readOverlay) {
+      readBtn.addEventListener('click', function() {
+        toggleReadOverlay();
+      });
+    }
+
+    function updateReadOverlaySize() {
+      if (!readOverlay) return;
+      var img = document.querySelector('.postcard-viewer-back .postcard-viewer-img');
+      if (!img) return;
+      var rect = img.getBoundingClientRect();
+      readOverlay.style.setProperty('--visible-img-width', rect.width + 'px');
+      readOverlay.style.setProperty('--visible-img-height', rect.height + 'px');
+    }
+
+    function toggleReadOverlay() {
+      if (readOverlay.classList.contains('active')) {
+        closeReadOverlay();
+      } else {
+        updateReadOverlaySize();
+        readOverlay.classList.add('active');
+        readBtn.classList.add('reading');
+        readBtn.setAttribute('aria-label', 'Hide transcript');
+      }
+    }
+
+    function closeReadOverlay() {
+      if (!readOverlay) return;
+      readOverlay.classList.remove('active');
+      if (readBtn) {
+        readBtn.classList.remove('reading');
+        readBtn.setAttribute('aria-label', 'Read transcript');
+      }
+    }
   });
 </script>

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -108,7 +108,7 @@ layout: default
     flipBtn.addEventListener('click', function() {
       isFlipped = !isFlipped;
       container.classList.toggle('flipped', isFlipped);
-      listenBtn.style.display = isFlipped ? 'flex' : 'none';
+      if (listenBtn) listenBtn.style.display = isFlipped ? 'flex' : 'none';
       if (readBtn) readBtn.style.display = isFlipped ? 'flex' : 'none';
       if (!isFlipped) closeReadOverlay();
     });

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -81,7 +81,7 @@ layout: default
     var listenBtn = document.querySelector('.postcard-listen-btn');
     var readBtn = document.querySelector('.postcard-read-btn');
     var readOverlay = document.getElementById('read-overlay');
-    var actionsEl = document.querySelector('.postcard-viewer-actions');
+    var viewerEl = document.querySelector('.postcard-viewer');
     var isFlipped = false;
 
     function updateViewerSize() {
@@ -91,7 +91,7 @@ layout: default
       var natRatio = img.naturalWidth / img.naturalHeight;
       var elemRatio = rect.width / rect.height;
       var visW = elemRatio > natRatio ? rect.height * natRatio : rect.width;
-      if (actionsEl) actionsEl.style.setProperty('--img-width', visW + 'px');
+      if (viewerEl) viewerEl.style.setProperty('--img-width', visW + 'px');
     }
 
     var frontImg = document.querySelector('.postcard-viewer-front .postcard-viewer-img');

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -12,6 +12,9 @@ layout: default
   {% endif %}
 {% endfor %}
 
+{% assign country_data = site.data.countries | where: "code", page.country | first %}
+{% assign country_name = country_data.name | default: page.country %}
+
 <div class="postcard-page">
   <a href="{{ '/posts.html' | relative_url }}" class="postcard-back-link">
     <svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -43,9 +46,6 @@ layout: default
         <button class="postcard-viewer-btn postcard-listen-btn" style="display:none">
           <img src="{{ '/assets/icons/speaker.svg' | relative_url }}" alt="Listen" class="postcard-viewer-icon">
         </button>
-        <button class="postcard-viewer-btn postcard-read-btn" style="display:none">
-          <img src="{{ '/assets/icons/transcript.svg' | relative_url }}" alt="Read" class="postcard-viewer-icon">
-        </button>
       </div>
       <button class="postcard-viewer-btn postcard-flip-btn" id="flip-btn">
         <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="postcard-viewer-icon">
@@ -54,10 +54,16 @@ layout: default
   </div>
 
   <div class="postcard-meta">
-    <p class="postcard-meta-item"><strong>Country:</strong> {{ page.country }}</p>
+    <p class="postcard-meta-item"><strong>Country:</strong> {{ country_name }}</p>
     <p class="postcard-meta-item"><strong>Topic:</strong> {{ page.topic }}</p>
     <p class="postcard-meta-item"><strong>Date:</strong> {{ page.date | date: "%B %d, %Y" }}</p>
   </div>
+
+  {% if content != '' %}
+  <div class="postcard-transcript">
+    {{ content }}
+  </div>
+  {% endif %}
 </div>
 
 <script>
@@ -65,14 +71,12 @@ layout: default
     const container = document.getElementById('card-container');
     const flipBtn = document.getElementById('flip-btn');
     const listenBtn = document.querySelector('.postcard-listen-btn');
-    const readBtn = document.querySelector('.postcard-read-btn');
     let isFlipped = false;
 
     flipBtn.addEventListener('click', function() {
       isFlipped = !isFlipped;
       container.classList.toggle('flipped', isFlipped);
       listenBtn.style.display = isFlipped ? 'flex' : 'none';
-      readBtn.style.display = isFlipped ? 'flex' : 'none';
     });
   });
 </script>

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -17,7 +17,12 @@ layout: default
 
 <div class="postcard-page">
   <aside class="postcard-sidebar">
-    <a href="{{ '/posts.html' | relative_url }}" class="postcard-back-link">All postcards</a>
+    <a href="{{ '/posts.html' | relative_url }}" class="postcard-back-link">
+      <svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M6 1L1 6L6 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      All postcards
+    </a>
 
     <div class="postcard-meta">
       <p class="postcard-meta-item"><strong>Country</strong><span>{{ country_name }}</span></p>
@@ -76,7 +81,25 @@ layout: default
     var listenBtn = document.querySelector('.postcard-listen-btn');
     var readBtn = document.querySelector('.postcard-read-btn');
     var readOverlay = document.getElementById('read-overlay');
+    var actionsEl = document.querySelector('.postcard-viewer-actions');
     var isFlipped = false;
+
+    function updateViewerSize() {
+      var img = document.querySelector('.postcard-viewer-front .postcard-viewer-img');
+      if (!img || !img.naturalWidth) return;
+      var rect = img.getBoundingClientRect();
+      var natRatio = img.naturalWidth / img.naturalHeight;
+      var elemRatio = rect.width / rect.height;
+      var visW = elemRatio > natRatio ? rect.height * natRatio : rect.width;
+      if (actionsEl) actionsEl.style.setProperty('--img-width', visW + 'px');
+    }
+
+    var frontImg = document.querySelector('.postcard-viewer-front .postcard-viewer-img');
+    if (frontImg) {
+      if (frontImg.complete) updateViewerSize();
+      else frontImg.addEventListener('load', updateViewerSize);
+    }
+    window.addEventListener('resize', updateViewerSize);
 
     flipBtn.addEventListener('click', function() {
       isFlipped = !isFlipped;

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -53,17 +53,17 @@ layout: default
     </div>
   </div>
 
-  <div class="postcard-meta">
-    <p class="postcard-meta-item"><strong>Country:</strong> {{ country_name }}</p>
-    <p class="postcard-meta-item"><strong>Topic:</strong> {{ page.topic }}</p>
-    <p class="postcard-meta-item"><strong>Date:</strong> {{ page.date | date: "%B %d, %Y" }}</p>
-  </div>
-
   {% if content != '' %}
   <div class="postcard-transcript">
     {{ content }}
   </div>
   {% endif %}
+
+  <div class="postcard-meta">
+    <p class="postcard-meta-item"><strong>Country:</strong> {{ country_name }}</p>
+    <p class="postcard-meta-item"><strong>Topic:</strong> {{ page.topic }}</p>
+    <p class="postcard-meta-item"><strong>Date:</strong> {{ page.date | date: "%B %d, %Y" }}</p>
+  </div>
 </div>
 
 <script>

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -120,10 +120,20 @@ layout: default
     function updateReadOverlaySize() {
       if (!readOverlay) return;
       var img = document.querySelector('.postcard-viewer-back .postcard-viewer-img');
-      if (!img) return;
+      if (!img || !img.naturalWidth || !img.naturalHeight) return;
       var rect = img.getBoundingClientRect();
-      readOverlay.style.setProperty('--visible-img-width', rect.width + 'px');
-      readOverlay.style.setProperty('--visible-img-height', rect.height + 'px');
+      var natRatio = img.naturalWidth / img.naturalHeight;
+      var elemRatio = rect.width / rect.height;
+      var visW, visH;
+      if (elemRatio > natRatio) {
+        visH = rect.height;
+        visW = rect.height * natRatio;
+      } else {
+        visW = rect.width;
+        visH = rect.width / natRatio;
+      }
+      readOverlay.style.setProperty('--visible-img-width', visW + 'px');
+      readOverlay.style.setProperty('--visible-img-height', visH + 'px');
     }
 
     function toggleReadOverlay() {

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -78,8 +78,16 @@
   pointer-events: auto;
 }
 
+.postcard-viewer-front,
+.postcard-viewer-back {
+  display: flex;
+  justify-content: center;
+}
+
 .postcard-viewer-img {
-  width: 100%;
+  max-width: 100%;
+  max-height: 65vh;
+  width: auto;
   height: auto;
   display: block;
   border-radius: 2px;
@@ -139,6 +147,19 @@
 
 .postcard-meta-item strong {
   color: var(--color-gray-5);
+}
+
+/* Transcript */
+.postcard-transcript {
+  margin-top: 24px;
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--color-gray-5);
+}
+
+.postcard-transcript p {
+  margin: 0;
 }
 
 /* Responsive */

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -1,26 +1,80 @@
 /* Standalone postcard page (for direct visits / SEO) */
 
 .postcard-page {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 24px 32px 48px;
+  display: flex;
+  padding: 0 32px 32px;
+  gap: 16px;
+  min-height: calc(100vh - 180px);
+}
+
+/* Sidebar — mirrors .sidebar from posts.css */
+.postcard-sidebar {
+  flex-shrink: 0;
+  width: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  padding: 0 2px;
+  position: sticky;
+  top: 120px;
+  align-self: flex-start;
 }
 
 .postcard-back-link {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 8px;
+  padding: 8px 0;
   font-family: var(--font-display);
-  font-size: 14px;
   font-weight: 500;
-  color: var(--color-gray-4);
+  font-size: 16px;
+  color: var(--color-gray-5);
   text-decoration: none;
-  margin-bottom: 24px;
   transition: color 0.2s;
+  margin-top: 32px;
 }
 
 .postcard-back-link:hover {
   color: var(--color-lavender);
+}
+
+/* Meta info */
+.postcard-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 24px 0;
+  border-top: 1px solid var(--color-gray-1);
+  margin-top: 16px;
+}
+
+.postcard-meta-item {
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-body);
+  font-size: 14px;
+  margin: 0;
+  padding: 4px 0;
+}
+
+.postcard-meta-item strong {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 12px;
+  color: var(--color-gray-3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.postcard-meta-item span {
+  color: var(--color-gray-5);
+  margin-top: 2px;
+}
+
+/* Main content area */
+.postcard-main {
+  flex: 1;
+  min-width: 0;
 }
 
 /* Viewer */
@@ -28,6 +82,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-top: 32px;
 }
 
 .postcard-viewer-number {
@@ -78,17 +133,11 @@
   pointer-events: auto;
 }
 
-.postcard-viewer-front,
-.postcard-viewer-back {
-  display: flex;
-  justify-content: center;
-}
-
 .postcard-viewer-img {
-  max-width: 100%;
-  max-height: 65vh;
-  width: auto;
+  width: 100%;
   height: auto;
+  max-height: 65vh;
+  object-fit: contain;
   display: block;
   border-radius: 2px;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15), 0px 4px 4px rgba(84, 65, 171, 0.2);
@@ -128,52 +177,75 @@
   height: auto;
 }
 
-/* Meta info */
-.postcard-meta {
-  margin-top: 32px;
-  padding-top: 16px;
-  border-top: 1px solid var(--color-gray-1);
+/* Read overlay */
+.postcard-read-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: var(--visible-img-width, 100%);
+  height: var(--visible-img-height, 100%);
+  background: rgba(255, 255, 255, 0.92);
   display: flex;
-  gap: 24px;
-  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  border-radius: 2px;
+  overflow-y: auto;
+  box-sizing: border-box;
 }
 
-.postcard-meta-item {
+.postcard-read-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.postcard-read-text {
   font-family: var(--font-body);
-  font-size: 14px;
-  color: var(--color-gray-4);
-  margin: 0;
-}
-
-.postcard-meta-item strong {
-  color: var(--color-gray-5);
-}
-
-/* Transcript */
-.postcard-transcript {
-  margin-top: 24px;
-  font-family: var(--font-body);
-  font-size: 16px;
+  font-size: 18px;
   line-height: 1.7;
   color: var(--color-gray-5);
+  text-align: center;
+  max-width: 480px;
+  margin: 0;
 }
 
-.postcard-transcript p {
+.postcard-read-text p {
   margin: 0;
+}
+
+.postcard-read-btn.reading .postcard-viewer-icon {
+  filter: drop-shadow(0 0 6px rgba(195, 177, 225, 0.7));
 }
 
 /* Responsive */
 @media (max-width: 768px) {
   .postcard-page {
-    padding: 16px 16px 32px;
+    flex-direction: column;
+    padding: 0 16px 32px;
+  }
+
+  .postcard-sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    position: static;
+    padding: 16px 0 0;
+  }
+
+  .postcard-back-link {
+    margin-top: 0;
+  }
+
+  .postcard-meta {
+    display: none;
   }
 
   .postcard-viewer-number {
     font-size: 20px;
-  }
-
-  .postcard-meta {
-    flex-direction: column;
-    gap: 8px;
   }
 }

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -255,7 +255,19 @@
   }
 
   .postcard-meta {
-    display: none;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 16px;
+    border-top: none;
+    margin-top: 0;
+    padding: 0;
+  }
+
+  .postcard-meta-item {
+    flex-direction: row;
+    gap: 6px;
+    align-items: baseline;
   }
 
   .postcard-viewer-number {

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -85,6 +85,15 @@
   padding-top: 32px;
 }
 
+.postcard-viewer-top-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: center;
+  width: var(--img-width, 100%);
+  margin-bottom: 8px;
+}
+
 .postcard-viewer-number {
   font-family: var(--font-display);
   font-weight: 500;
@@ -98,10 +107,6 @@
     rgba(253, 224, 118, 0.55)
   );
   border-radius: 20px;
-  align-self: center;
-  width: var(--img-width, 100%);
-  box-sizing: border-box;
-  margin-bottom: 8px;
 }
 
 .postcard-viewer-wrapper {

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -89,10 +89,19 @@
   font-family: var(--font-display);
   font-weight: 500;
   font-size: 24px;
-  color: var(--color-gray-5);
-  align-self: flex-start;
+  color: var(--color-white);
+  padding: 4px 12px;
+  background: linear-gradient(
+    135deg,
+    rgba(144, 126, 223, 0.55),
+    rgba(217, 170, 225, 0.55),
+    rgba(253, 224, 118, 0.55)
+  );
+  border-radius: 20px;
+  align-self: center;
+  width: var(--img-width, 100%);
+  box-sizing: border-box;
   margin-bottom: 8px;
-  padding-left: 4px;
 }
 
 .postcard-viewer-wrapper {
@@ -146,6 +155,7 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  align-self: center;
   width: var(--img-width, 100%);
   margin-top: 24px;
 }

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -135,12 +135,10 @@
 
 .postcard-viewer-img {
   width: 100%;
-  height: auto;
   max-height: 65vh;
   object-fit: contain;
   display: block;
   border-radius: 2px;
-  box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15), 0px 4px 4px rgba(84, 65, 171, 0.2);
 }
 
 /* Action buttons */
@@ -148,7 +146,7 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  width: 100%;
+  width: var(--img-width, 100%);
   margin-top: 24px;
 }
 


### PR DESCRIPTION
Notion: [QPB-74](https://www.notion.so/33833daa5a0080eb99f2d4cc49b2fe64)

## Summary

- Display full country name (e.g. "United Kingdom") instead of ISO code ("GB") via `_data/countries.yml` lookup
- Redesign post page to match the posts.html two-column layout: sidebar (left) with ← back link + Country/Topic/Date meta, postcard viewer (right)
- Number pill (#49) uses the same gradient style as the modal, aligned to the left edge of the postcard via `--img-width`
- Action buttons (listen/read/flip) aligned to the postcard width via `--img-width`, matching the modal's bottom section behaviour
- Read button restored as a transcript overlay on the back face — same visual and interaction as the modal; overlay size computed from natural image ratio (not element box) for correct fit with `object-fit: contain`
- Listen button only rendered when `page.audio` is set — hidden entirely for postcards without audio
- Portrait and landscape postcards both handled via `width: 100%; max-height: 65vh; object-fit: contain`
- No box-shadow on postcard image, matching the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)