### PR TITLE
feat: mobile device testing and fixing (QPB-52)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -50,6 +50,18 @@
   /* Fonts */
   --font-display: 'Albert Sans', sans-serif;
   --font-body: 'Atkinson Hyperlegible Next', 'Atkinson Hyperlegible', sans-serif;
+
+  /* Z-index stacking layers */
+  --z-postcard-hover: 2;
+  --z-mobile-sidebar: 10;
+  --z-send-btn: 100;
+  --z-filter-dropdown: 200;
+  --z-modal-overlay: 2000;
+  --z-header: 2100;
+  --z-fullscreen: 3000;
+
+  /* Breakpoints (reference only — CSS vars can't be used in @media queries)
+     mobile: 768px  |  tablet: 1024px */
 }
 
 /* Reset */
@@ -72,7 +84,7 @@ body {
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 2100;
+  z-index: var(--z-header);
   background: var(--color-white);
   padding: 32px 25px 16px; /* 16px bottom gives breathing room below the logo */
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -222,9 +222,9 @@ body {
     --offset-logo-lines-left: 104px;
     --width-sidebar: 148px;
     --sticky-top-sidebar: 110px;
-    --size-icon-action: 56px;
-    --size-icon-send-w: 40px;
-    --size-icon-send-h: 28px;
+    --size-icon-action: 46px;
+    --size-icon-send-w: 36px;
+    --size-icon-send-h: 25px;
     --font-size-send-label: 13px;
   }
 

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -252,29 +252,32 @@
   .postcard-page {
     flex-direction: column;
     padding: 0 16px 32px;
+    gap: 8px;
   }
 
+  /* Make sidebar transparent so its children reorder within postcard-page */
   .postcard-sidebar {
-    width: 100%;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    position: static;
-    padding: 16px 0 0;
+    display: contents;
   }
 
   .postcard-back-link {
-    margin-top: 0;
+    order: 0;
+    margin-top: 16px;
+  }
+
+  .postcard-main {
+    order: 1;
   }
 
   .postcard-meta {
+    order: 2;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     gap: 16px;
-    border-top: none;
-    margin-top: 0;
-    padding: 0;
+    padding: 16px 0 0;
+    border-top: 1px solid var(--color-gray-1);
+    margin-top: 4px;
   }
 
   .postcard-meta-item {

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -267,6 +267,7 @@
 
   .postcard-main {
     order: 1;
+    flex: none;
   }
 
   .postcard-meta {

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -781,7 +781,7 @@
 @media (max-width: 768px) {
   .landing-layout {
     flex-direction: column;
-    padding: 0 16px 16px;
+    padding: 0 16px 96px;
   }
 
   .sidebar {
@@ -805,7 +805,7 @@
     border-radius: 8px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     padding: 8px;
-    z-index: 100;
+    z-index: 200;
     max-height: 300px;
     top: 100%;
     left: 0;
@@ -819,6 +819,12 @@
     bottom: 16px;
     left: 16px;
     width: calc(100vw - 32px);
+    flex-direction: row;
+    gap: 12px;
+    padding: 12px 24px;
+    background: var(--color-white);
+    box-shadow: 0 2px 12px rgba(84, 65, 171, 0.18);
+    border-radius: 16px;
   }
 
   .reply-card {

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -829,16 +829,17 @@
     z-index: 100;
     background: var(--color-white);
     border-radius: 20px;
+    border: 2px solid var(--color-lavender);
   }
 
-  /* Show rainbow border by default on mobile so button is clearly visible */
+  /* Hide rainbow border on mobile — solid border used instead */
   .send-postcard-btn::before {
-    opacity: 0.8;
-    animation: rainbow-spin 4s linear infinite;
+    opacity: 0;
+    animation: none;
   }
 
   .site-footer {
-    padding-bottom: 80px;
+    padding-bottom: 100px;
   }
 
   .reply-card {

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -818,22 +818,22 @@
     position: relative;
   }
 
-  /* Send button floats at bottom on mobile */
+  /* Send button floats at bottom-center on mobile */
   .send-postcard-btn {
     bottom: 16px;
-    left: 16px;
+    left: 50%;
+    transform: translateX(-50%);
     top: auto;
     right: auto;
-    width: calc(100vw - 32px);
+    width: var(--width-sidebar);
     z-index: 100;
-    flex-direction: row;
-    gap: 12px;
-    padding: 12px 24px;
+    background: var(--color-white);
+    border-radius: 20px;
   }
 
   /* Show rainbow border by default on mobile so button is clearly visible */
   .send-postcard-btn::before {
-    opacity: 0.7;
+    opacity: 0.8;
     animation: rainbow-spin 4s linear infinite;
   }
 

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -129,7 +129,7 @@
   bottom: 32px;
   left: 32px;
   width: var(--width-sidebar);
-  z-index: 100;
+  z-index: var(--z-send-btn);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -298,7 +298,7 @@
 .postcard-item:hover {
   scale: 1.04;
   box-shadow: 0 6px 16px rgba(84, 65, 171, 0.35);
-  z-index: 2;
+  z-index: var(--z-postcard-hover);
 }
 
 .postcard-link {
@@ -330,7 +330,7 @@
   width: 81px;
   height: 81px;
   overflow: hidden;
-  z-index: 2;
+  z-index: var(--z-postcard-hover);
   pointer-events: none;
 }
 
@@ -362,7 +362,7 @@
   display: none;
   position: fixed;
   inset: 0;
-  z-index: 2000;
+  z-index: var(--z-modal-overlay);
 }
 
 .modal-overlay.active {
@@ -609,7 +609,7 @@
   display: none;
   position: fixed;
   inset: 0;
-  z-index: 3000;
+  z-index: var(--z-fullscreen);
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.3);
@@ -791,7 +791,7 @@
     justify-content: space-between;
     position: relative;
     top: auto;
-    z-index: 10;
+    z-index: var(--z-mobile-sidebar);
   }
 
   .filters {
@@ -808,7 +808,7 @@
     border-radius: 8px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     padding: 8px;
-    z-index: 200;
+    z-index: var(--z-filter-dropdown);
     max-height: 300px;
     top: 100%;
     left: 0;
@@ -826,7 +826,7 @@
     top: auto;
     right: auto;
     width: var(--width-sidebar);
-    z-index: 100;
+    z-index: var(--z-send-btn);
     background: var(--color-white);
     border-radius: 20px;
     border: 2px solid var(--color-lavender);

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -781,7 +781,7 @@
 @media (max-width: 768px) {
   .landing-layout {
     flex-direction: column;
-    padding: 0 16px 96px;
+    padding: 0 16px 16px;
   }
 
   .sidebar {
@@ -789,6 +789,9 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+    position: relative;
+    top: auto;
+    z-index: 10;
   }
 
   .filters {
@@ -815,16 +818,20 @@
     position: relative;
   }
 
+  /* Move send button into the header area on mobile */
   .send-postcard-btn {
-    bottom: 16px;
-    left: 16px;
-    width: calc(100vw - 32px);
+    top: 20px;
+    right: 16px;
+    bottom: auto;
+    left: auto;
+    width: auto;
+    z-index: 2200;
     flex-direction: row;
-    gap: 12px;
-    padding: 12px 24px;
+    gap: 8px;
+    padding: 8px 14px;
     background: var(--color-white);
-    box-shadow: 0 2px 12px rgba(84, 65, 171, 0.18);
-    border-radius: 16px;
+    box-shadow: 0 1px 0 var(--color-gray-1), 0 2px 8px rgba(84, 65, 171, 0.12);
+    border-radius: 20px;
   }
 
   .reply-card {

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -781,7 +781,7 @@
 @media (max-width: 768px) {
   .landing-layout {
     flex-direction: column;
-    padding: 0 16px 16px;
+    padding: 0 16px 96px;
   }
 
   .sidebar {
@@ -818,20 +818,27 @@
     position: relative;
   }
 
-  /* Move send button into the header area on mobile */
+  /* Send button floats at bottom on mobile */
   .send-postcard-btn {
-    top: 20px;
-    right: 16px;
-    bottom: auto;
-    left: auto;
-    width: auto;
-    z-index: 2200;
+    bottom: 16px;
+    left: 16px;
+    top: auto;
+    right: auto;
+    width: calc(100vw - 32px);
+    z-index: 100;
     flex-direction: row;
-    gap: 8px;
-    padding: 8px 14px;
-    background: var(--color-white);
-    box-shadow: 0 1px 0 var(--color-gray-1), 0 2px 8px rgba(84, 65, 171, 0.12);
-    border-radius: 20px;
+    gap: 12px;
+    padding: 12px 24px;
+  }
+
+  /* Show rainbow border by default on mobile so button is clearly visible */
+  .send-postcard-btn::before {
+    opacity: 0.7;
+    animation: rainbow-spin 4s linear infinite;
+  }
+
+  .site-footer {
+    padding-bottom: 80px;
   }
 
   .reply-card {

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -68,6 +68,18 @@ function initFilters() {
     countryBtn.classList.remove('has-selection');
     clearFilter();
   });
+
+  document.addEventListener('click', function(e) {
+    if (!e.target.closest('.filter-name') && !e.target.closest('.filter-options')) {
+      filterBtns.forEach(btn => {
+        btn.classList.remove('expanded');
+        btn.setAttribute('aria-expanded', 'false');
+        const filterType = btn.dataset.filter;
+        const options = document.getElementById(filterType + '-options');
+        if (options) options.classList.remove('open');
+      });
+    }
+  });
 }
 
 function filterByCountry(country) {

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -79,7 +79,7 @@ function initFilters() {
         if (options) options.classList.remove('open');
       });
     }
-  });
+  }, { capture: true });
 }
 
 function filterByCountry(country) {


### PR DESCRIPTION
Notion: [QPB-52](https://www.notion.so/33833daa5a0081b89fa6cef39834ec2b)

## Summary
- Reduced action button icon size on mobile (`--size-icon-action`: 56px → 46px) so buttons are smaller than on tablet
- Fixed send postcard button on mobile: added white background + shadow so it's visible over postcard images, switched to horizontal (icon + label) layout, added bottom padding to prevent grid content hiding behind the fixed button
- Added close-on-outside-click for the country filter dropdown on mobile
- Raised filter dropdown z-index on mobile to appear above the send button
- Reordered postcard detail page on mobile: back link at top → postcard viewer → metadata below the image (using CSS `display: contents` + `order`)