### PR TITLE
feat: revamp 404 page with postcard design system

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,28 +1,24 @@
 ---
 layout: default
+title: 404 — Page not found
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
+<link rel="stylesheet" href="{{ '/assets/css/postcard.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/404.css' | relative_url }}">
 
+<div class="error-page">
+  <a href="{{ '/posts.html' | relative_url }}" class="postcard-back-link error-back-link">
+    <svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M6 1L1 6L6 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+    All postcards
+  </a>
 
-
-<div class="container">
-  <h1>404? More like 4-get it, queen! 👑</h1>
-
-  <img src="{{ '/assets/images/404-drag-queen.png' | relative_url }}" alt="404"/>
-
-  <p><strong>This page got lost in the mail 📬</strong></p>
-  <p>While this page has gone missing, your stories are never forgotten. Find your way back to the main page and send some love!</p>
+  <div class="error-content">
+    <span class="postcard-viewer-number">404</span>
+    <img src="{{ '/assets/images/404-drag-queen.png' | relative_url }}" alt="A drag queen celebrating amid lost mail" class="error-img">
+    <h1 class="error-title">4-get it, queen! 👑</h1>
+    <p class="error-body">This page got lost in the mail. While it's gone missing, most stories are never forgotten. Find your way back and send some love!</p>
+    <a href="{{ '/posts.html' | relative_url }}" class="error-cta">Browse all postcards</a>
+  </div>
 </div>

--- a/assets/css/404.css
+++ b/assets/css/404.css
@@ -1,0 +1,112 @@
+/* 404 error page */
+
+.error-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 32px 32px;
+  min-height: calc(100vh - 180px);
+}
+
+.error-back-link {
+  align-self: flex-start;
+  margin-top: 32px;
+}
+
+.error-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  flex: 1;
+  justify-content: center;
+  padding-bottom: 32px;
+  max-width: 480px;
+}
+
+.error-img {
+  max-width: 260px;
+  width: 100%;
+  display: block;
+}
+
+.error-title {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 32px;
+  line-height: 1.1;
+  letter-spacing: -0.5px;
+  color: var(--color-gray-5);
+  margin: 4px 0 0;
+}
+
+.error-body {
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--color-gray-4);
+  margin: 0;
+}
+
+.error-cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 12px 20px;
+  background: var(--color-lavender);
+  color: var(--color-white);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  border-radius: 8px;
+  margin-top: 4px;
+  transition: background 0.2s;
+}
+
+.error-cta:hover {
+  background: var(--color-lavender-dark);
+}
+
+/* Tablet */
+@media (max-width: 1024px) {
+  .error-back-link {
+    margin-top: 16px;
+  }
+
+  .error-img {
+    max-width: 220px;
+  }
+
+  .error-title {
+    font-size: 28px;
+  }
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .error-page {
+    padding: 0 16px 24px;
+  }
+
+  .error-content {
+    gap: 8px;
+  }
+
+  .error-img {
+    max-width: 160px;
+  }
+
+  .error-title {
+    font-size: 22px;
+  }
+
+  .error-body {
+    font-size: 15px;
+  }
+
+  .error-cta {
+    padding: 10px 18px;
+    font-size: 14px;
+  }
+}


### PR DESCRIPTION
Notion: [QPB-35](https://www.notion.so/33833daa5a008150909ad019928f7b08)

## Summary
- Replaced the old inline-styled 404 page with a centered, above-the-fold layout using the site's design system
- Reuses postcard visual elements: number badge (styled as "404"), back link, font tokens, and color palette
- Image is appropriately sized (260px desktop, 220px tablet, 160px mobile) so all content fits without scrolling
- Responsive for tablet and mobile breakpoints
- Added `assets/css/404.css` for 404-specific styles, loading `postcard.css` for shared components