### PR TITLE
feat: add share button to postcard modal (QPB-45)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://www.queerpostbox.com" # the base hostname & protocol for your site, e.g. http://example.com
 # twitter_username: jekyllrb
 # github_username:  jekyll
 

--- a/_includes/modals/postcard.html
+++ b/_includes/modals/postcard.html
@@ -1,4 +1,4 @@
-<div id="share-toast" role="status" aria-live="polite">Link copied!</div>
+<div id="share-toast" role="alert" aria-live="assertive">Link copied!</div>
 
 <!-- Postcard Modal -->
 <div id="postcard-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-label="Postcard viewer">

--- a/_includes/modals/postcard.html
+++ b/_includes/modals/postcard.html
@@ -1,3 +1,5 @@
+<div id="share-toast" role="status" aria-live="polite">Link copied!</div>
+
 <!-- Postcard Modal -->
 <div id="postcard-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-label="Postcard viewer">
   <div class="modal-backdrop"></div>
@@ -30,9 +32,14 @@
           <img src="{{ '/assets/icons/transcript.svg' | relative_url }}" alt="Read" class="modal-action-icon">
         </button>
       </div>
-      <button class="modal-action-btn modal-flip-btn">
-        <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="modal-action-icon">
-      </button>
+      <div class="modal-right-btns">
+        <button class="modal-action-btn modal-share-btn" aria-label="Share postcard">
+          <img src="{{ '/assets/icons/share.svg' | relative_url }}" alt="Share" class="modal-action-icon">
+        </button>
+        <button class="modal-action-btn modal-flip-btn">
+          <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="modal-action-icon">
+        </button>
+      </div>
     </div>
     <button class="modal-arrow-down" aria-label="Send a reply">
       <svg width="32" height="16" viewBox="0 0 32 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/_includes/modals/postcard.html
+++ b/_includes/modals/postcard.html
@@ -1,4 +1,4 @@
-<div id="share-toast" role="alert" aria-live="assertive">Link copied!</div>
+<div id="share-toast" role="alert" aria-live="assertive"></div>
 
 <!-- Postcard Modal -->
 <div id="postcard-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-label="Postcard viewer">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,18 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+  {% if page.image-front %}
+  <meta property="og:title" content="{{ page.title }} - {{ site.title }}">
+  <meta property="og:description" content="Queer stories, on postcards.">
+  <meta property="og:image" content="{{ site.url }}{{ page.image-front }}">
+  <meta property="og:url" content="{{ site.url }}{{ page.url }}">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Queer Postbox">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ page.title }} - {{ site.title }}">
+  <meta name="twitter:description" content="Queer stories, on postcards.">
+  <meta name="twitter:image" content="{{ site.url }}{{ page.image-front }}">
+  {% endif %}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@400;500;600;700;800&family=Atkinson+Hyperlegible+Next:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -70,13 +70,20 @@ layout: default
           </button>
           {% endif %}
         </div>
-        <button class="postcard-viewer-btn postcard-flip-btn" id="flip-btn">
-          <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="postcard-viewer-icon">
-        </button>
+        <div class="postcard-viewer-right-btns">
+          <button class="postcard-viewer-btn postcard-share-btn" aria-label="Share postcard">
+            <img src="{{ '/assets/icons/share.svg' | relative_url }}" alt="Share" class="postcard-viewer-icon">
+          </button>
+          <button class="postcard-viewer-btn postcard-flip-btn" id="flip-btn">
+            <img src="{{ '/assets/icons/flip.svg' | relative_url }}" alt="Flip" class="postcard-viewer-icon">
+          </button>
+        </div>
       </div>
     </div>
   </div>
 </div>
+
+<div id="share-toast" role="alert" aria-live="assertive">Link copied!</div>
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
@@ -107,6 +114,27 @@ layout: default
       updateViewerSize();
       if (readOverlay && readOverlay.classList.contains('active')) updateReadOverlaySize();
     });
+
+    var shareBtn = document.querySelector('.postcard-share-btn');
+    var shareToast = document.getElementById('share-toast');
+    var shareToastTimer = null;
+    if (shareBtn) {
+      shareBtn.addEventListener('click', function() {
+        var url = window.location.href;
+        var title = document.title;
+        if (navigator.share) {
+          navigator.share({ title: title, url: url }).catch(function() {});
+        } else if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(url).then(function() {
+            if (shareToast) {
+              shareToast.classList.add('visible');
+              clearTimeout(shareToastTimer);
+              shareToastTimer = setTimeout(function() { shareToast.classList.remove('visible'); }, 2500);
+            }
+          }).catch(function() {});
+        }
+      });
+    }
 
     flipBtn.addEventListener('click', function() {
       isFlipped = !isFlipped;

--- a/_layouts/postcard.html
+++ b/_layouts/postcard.html
@@ -83,7 +83,7 @@ layout: default
   </div>
 </div>
 
-<div id="share-toast" role="alert" aria-live="assertive">Link copied!</div>
+<div id="share-toast" role="alert" aria-live="assertive"></div>
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
@@ -122,16 +122,29 @@ layout: default
       shareBtn.addEventListener('click', function() {
         var url = window.location.href;
         var title = document.title;
+        function showToast() {
+          if (!shareToast) return;
+          shareToast.textContent = 'Link copied!';
+          shareToast.classList.add('visible');
+          clearTimeout(shareToastTimer);
+          shareToastTimer = setTimeout(function() {
+            shareToast.classList.remove('visible');
+            shareToast.textContent = '';
+          }, 2500);
+        }
         if (navigator.share) {
           navigator.share({ title: title, url: url }).catch(function() {});
         } else if (navigator.clipboard && navigator.clipboard.writeText) {
-          navigator.clipboard.writeText(url).then(function() {
-            if (shareToast) {
-              shareToast.classList.add('visible');
-              clearTimeout(shareToastTimer);
-              shareToastTimer = setTimeout(function() { shareToast.classList.remove('visible'); }, 2500);
-            }
-          }).catch(function() {});
+          navigator.clipboard.writeText(url).then(showToast).catch(function() {});
+        } else {
+          var ta = document.createElement('textarea');
+          ta.value = url;
+          ta.style.cssText = 'position:fixed;left:-9999px;top:-9999px';
+          document.body.appendChild(ta);
+          ta.focus();
+          ta.select();
+          try { if (document.execCommand('copy')) showToast(); } catch(e) {}
+          document.body.removeChild(ta);
         }
       });
     }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -248,3 +248,32 @@ body {
     padding: 32px 16px;
   }
 }
+
+/* Share toast notification */
+#share-toast {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%) translateY(8px);
+  background: linear-gradient(
+    135deg,
+    rgba(144, 126, 223, 0.55),
+    rgba(217, 170, 225, 0.55),
+    rgba(253, 224, 118, 0.55)
+  );
+  color: var(--color-white);
+  padding: 4px 16px;
+  border-radius: 20px;
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 16px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s, transform 0.2s;
+  z-index: 9999;
+}
+
+#share-toast.visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}

--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -169,6 +169,12 @@
   gap: 16px;
 }
 
+.postcard-viewer-right-btns {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
 .postcard-viewer-btn {
   display: flex;
   align-items: center;

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -452,8 +452,9 @@
 
 /* Card flip container */
 .modal-postcard-wrapper {
-  width: 100%;
+  width: var(--img-width, 100%);
   perspective: 1200px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35), 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .modal-card-container {
@@ -510,6 +511,12 @@
 .modal-accessibility-btns {
   display: flex;
   gap: 16px;
+}
+
+.modal-right-btns {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
 }
 
 .modal-action-btn {
@@ -867,6 +874,29 @@
   .postcard-grid {
     columns: 1;
   }
+}
+
+/* Share toast notification */
+#share-toast {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%) translateY(8px);
+  background: rgba(40, 36, 58, 0.9);
+  color: #FFFCFA;
+  padding: 10px 20px;
+  border-radius: 20px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s, transform 0.2s;
+  z-index: 9999;
+}
+
+#share-toast.visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -452,9 +452,8 @@
 
 /* Card flip container */
 .modal-postcard-wrapper {
-  width: var(--img-width, 100%);
+  width: 100%;
   perspective: 1200px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35), 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .modal-card-container {
@@ -497,6 +496,7 @@
   object-fit: contain;
   display: block;
   border-radius: 2px;
+  filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.35));
 }
 
 /* Bottom section: accessibility + flip */

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -876,28 +876,6 @@
   }
 }
 
-/* Share toast notification */
-#share-toast {
-  position: fixed;
-  bottom: 32px;
-  left: 50%;
-  transform: translateX(-50%) translateY(8px);
-  background: rgba(40, 36, 58, 0.9);
-  color: #FFFCFA;
-  padding: 10px 20px;
-  border-radius: 20px;
-  font-family: var(--font-body);
-  font-size: 14px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s, transform 0.2s;
-  z-index: 9999;
-}
-
-#share-toast.visible {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
-}
 
 @media (prefers-reduced-motion: reduce) {
   .send-postcard-btn::after {

--- a/assets/icons/share.svg
+++ b/assets/icons/share.svg
@@ -1,0 +1,19 @@
+<svg width="72" height="92" viewBox="0 0 72 92" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_share)">
+<rect x="4" y="2" width="64" height="64" rx="32" fill="#FFFCFA" shape-rendering="crispEdges"/>
+<path d="M28 28L36 20L44 28M36 20V45M22 45V55H50V45" stroke="#100E0E" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="36" y="84" fill="#FFFCFA" font-family="sans-serif" font-weight="700" font-size="11" text-anchor="middle" letter-spacing="0.5">SHARE</text>
+</g>
+<defs>
+<filter id="filter0_d_share" x="0" y="0" width="72" height="92" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_share"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_share" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -604,7 +604,7 @@ function sharePostcard() {
 
   if (navigator.share) {
     navigator.share({ title: title, url: url }).catch(function() {});
-  } else if (navigator.clipboard) {
+  } else if (navigator.clipboard && navigator.clipboard.writeText) {
     navigator.clipboard.writeText(url).then(function() {
       showShareToast();
     }).catch(function() {});

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -608,16 +608,27 @@ function sharePostcard() {
     navigator.clipboard.writeText(url).then(function() {
       showShareToast();
     }).catch(function() {});
+  } else {
+    var ta = document.createElement('textarea');
+    ta.value = url;
+    ta.style.cssText = 'position:fixed;left:-9999px;top:-9999px';
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    try { if (document.execCommand('copy')) showShareToast(); } catch(e) {}
+    document.body.removeChild(ta);
   }
 }
 
 function showShareToast() {
   var toast = document.getElementById('share-toast');
   if (!toast) return;
+  toast.textContent = 'Link copied!';
   toast.classList.add('visible');
   clearTimeout(shareToastTimer);
   shareToastTimer = setTimeout(function() {
     toast.classList.remove('visible');
+    toast.textContent = '';
   }, 2500);
 }
 

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -592,6 +592,33 @@ function updateListenButtonState() {
   }
 }
 
+var shareToastTimer = null;
+
+function sharePostcard() {
+  if (!currentPostcard) return;
+  var permalink = currentPostcard.dataset.permalink;
+  var title = currentPostcard.dataset.title || '';
+  var url = window.location.origin + permalink;
+
+  if (navigator.share) {
+    navigator.share({ title: title, url: url }).catch(function() {});
+  } else {
+    navigator.clipboard.writeText(url).then(function() {
+      showShareToast();
+    }).catch(function() {});
+  }
+}
+
+function showShareToast() {
+  var toast = document.getElementById('share-toast');
+  if (!toast) return;
+  toast.classList.add('visible');
+  clearTimeout(shareToastTimer);
+  shareToastTimer = setTimeout(function() {
+    toast.classList.remove('visible');
+  }, 2500);
+}
+
 function openModalBySlug(slug) {
   const postcardElement = document.querySelector('[data-slug="' + slug + '"]');
   if (postcardElement) {
@@ -712,6 +739,12 @@ document.addEventListener('DOMContentLoaded', function() {
   postcardModal.querySelector('.modal-read-btn').addEventListener('click', function(e) {
     e.stopPropagation();
     toggleReadOverlay();
+  });
+
+  // Share button — native share sheet with clipboard fallback
+  postcardModal.querySelector('.modal-share-btn').addEventListener('click', function(e) {
+    e.stopPropagation();
+    sharePostcard();
   });
 
   // ==================

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -256,10 +256,12 @@ function openModal(postcardElement, skipAnimation) {
   clone.className = 'fly-clone';
   clone.style.cssText = 'position:fixed;z-index:2001;border-radius:4px;pointer-events:none;' +
     'object-fit:contain;background:transparent;' +
+    'filter:drop-shadow(0 6px 16px rgba(84,65,171,0.35));' +
     'left:' + sourceRect.left + 'px;top:' + sourceRect.top + 'px;' +
     'width:' + sourceRect.width + 'px;height:' + sourceRect.height + 'px;' +
     'transition:left 0.32s cubic-bezier(0.4,0,0.15,1),top 0.32s cubic-bezier(0.4,0,0.15,1),' +
-    'width 0.32s cubic-bezier(0.4,0,0.15,1),height 0.32s cubic-bezier(0.4,0,0.15,1);';
+    'width 0.32s cubic-bezier(0.4,0,0.15,1),height 0.32s cubic-bezier(0.4,0,0.15,1),' +
+    'filter 0.32s cubic-bezier(0.4,0,0.15,1);';
   document.body.appendChild(clone);
 
   // Force reflow
@@ -270,6 +272,7 @@ function openModal(postcardElement, skipAnimation) {
   clone.style.top = (destCenterY - renderedH / 2) + 'px';
   clone.style.width = renderedW + 'px';
   clone.style.height = renderedH + 'px';
+  clone.style.filter = 'drop-shadow(0 6px 16px rgba(0,0,0,0.35))';
 
   // Animate backdrop blur in sync with fly animation
   var backdrop = postcardModal.querySelector('.modal-backdrop');
@@ -288,19 +291,16 @@ function openModal(postcardElement, skipAnimation) {
   }
   requestAnimationFrame(tickBlurIn);
 
-  function onFlyEnd() {
+  function onFlyEnd(e) {
+    if (e.propertyName !== 'width') return;
     clone.removeEventListener('transitionend', onFlyEnd);
     if (flyAborted) { clone.remove(); return; }
     postcardModal._abortFlyIn = null;
-    // Crossfade: show modal while fading clone out
+    // Instant swap: remove clone and show modal in the same frame
+    clone.remove();
     details.style.visibility = '';
     details.style.opacity = '';
     details.classList.remove('fly-hidden');
-    clone.style.transition = 'opacity 0.15s ease';
-    clone.style.opacity = '0';
-    setTimeout(function() {
-      clone.remove();
-    }, 160);
     postcardModal.querySelector('.modal-flip-btn').focus();
   }
   clone.addEventListener('transitionend', onFlyEnd);
@@ -308,10 +308,10 @@ function openModal(postcardElement, skipAnimation) {
   // Safety timeout
   setTimeout(function() {
     if (clone.parentNode) {
+      clone.remove();
       details.style.visibility = '';
       details.style.opacity = '';
       details.classList.remove('fly-hidden');
-      clone.remove();
     }
   }, 500);
 }
@@ -364,6 +364,7 @@ function closeModal(fromPopstate) {
     var clone = sourceImg.cloneNode();
     clone.className = 'fly-clone';
     clone.style.cssText = 'position:fixed;z-index:2001;border-radius:4px;pointer-events:none;' +
+      'filter:drop-shadow(0 6px 16px rgba(0,0,0,0.35));' +
       'left:' + (destCenterX - renderedW / 2) + 'px;top:' + (destCenterY - renderedH / 2) + 'px;' +
       'width:' + renderedW + 'px;height:' + renderedH + 'px;' +
       'transition:all 0.28s cubic-bezier(0.4, 0, 0.15, 1);';
@@ -391,6 +392,7 @@ function closeModal(fromPopstate) {
     clone.style.top = sourceRect.top + 'px';
     clone.style.width = sourceRect.width + 'px';
     clone.style.height = sourceRect.height + 'px';
+    clone.style.filter = 'drop-shadow(0 6px 16px rgba(84,65,171,0.35))';
 
     function onCloseEnd() {
       clone.removeEventListener('transitionend', onCloseEnd);

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -604,7 +604,7 @@ function sharePostcard() {
 
   if (navigator.share) {
     navigator.share({ title: title, url: url }).catch(function() {});
-  } else {
+  } else if (navigator.clipboard) {
     navigator.clipboard.writeText(url).then(function() {
       showShareToast();
     }).catch(function() {});


### PR DESCRIPTION
## Summary
- Adds a share button to the postcard modal, sitting to the left of the flip button
- Uses the native Web Share API on supporting browsers (mobile share sheet); falls back to copying the permalink to clipboard with a toast notification
- Includes a new `share.svg` icon matching the existing button design system

🤖 Generated with [Claude Code](https://claude.com/claude-code)