### PR TITLE
fix: remove site name from OG/Twitter title on postcard pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
   {% if page.image-front %}
-  <meta property="og:title" content="{{ page.title }} - {{ site.title }}">
+  <meta property="og:title" content="{{ page.title }}">
   <meta property="og:description" content="Queer stories, on postcards.">
   <meta property="og:image" content="{{ site.url }}{{ page.image-front }}">
   <meta property="og:url" content="{{ site.url }}{{ page.url }}">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="Queer Postbox">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{{ page.title }} - {{ site.title }}">
+  <meta name="twitter:title" content="{{ page.title }}">
   <meta name="twitter:description" content="Queer stories, on postcards.">
   <meta name="twitter:image" content="{{ site.url }}{{ page.image-front }}">
   {% endif %}


### PR DESCRIPTION
## Summary
- OG and Twitter Card titles were showing "Postcard Title - queerpostbox", which made the site name redundant since it's already shown as a separate line in share previews
- Changed `og:title` and `twitter:title` to use only the postcard title

🤖 Generated with [Claude Code](https://claude.com/claude-code)