### PR TITLE
fix: extend header behind browser chrome on Firefox mobile

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
   {% if page.image-front %}
   <meta property="og:title" content="{{ page.title }}">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -144,6 +144,7 @@ body {
 /* Page content */
 .page-content {
   width: 100%;
+  isolation: isolate; /* prevent child stacking contexts from escaping above the sticky header */
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` to allow sticky header to extend behind browser UI
- Add `isolation: isolate` to prevent postcard compositor layers from rendering above the sticky header on Firefox mobile
- Ensures white header background fills the browser chrome area

🤖 Generated with [Claude Code](https://claude.com/claude-code)