### PR TITLE
fix: move isolation to postcard grid so modals render above header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,6 +28,12 @@
     {{ content }}
   </main>
 
+  {% if page.include_modals %}
+    {% include modals/postcard.html %}
+    {% include modals/reply.html %}
+    {% include modals/send.html %}
+  {% endif %}
+
   {% include footer.html %}
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -141,7 +141,9 @@ body {
   height: var(--size-logo-lines-h);
 }
 
-/* Page content */
+/* Page content
+   NOTE: Do not add isolation, z-index, or transforms here —
+   modals must be able to layer above the sticky header */
 .page-content {
   width: 100%;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -144,7 +144,6 @@ body {
 /* Page content */
 .page-content {
   width: 100%;
-  isolation: isolate; /* prevent child stacking contexts from escaping above the sticky header */
 }
 
 /* Footer */

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -279,6 +279,7 @@
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15), 0px 4px 4px rgba(84, 65, 171, 0.2);
   border-radius: 4px;
   padding: 16px;
+  isolation: isolate; /* prevent postcard will-change layers from escaping above the sticky header */
 }
 
 .postcard-item {

--- a/posts.html
+++ b/posts.html
@@ -1,6 +1,7 @@
 ---
 layout: posts
 title: All Postcards
+include_modals: true
 ---
 
 <div class="landing-layout">
@@ -73,6 +74,3 @@ title: All Postcards
   </div>
 </div>
 
-{% include modals/postcard.html %}
-{% include modals/reply.html %}
-{% include modals/send.html %}


### PR DESCRIPTION
## Summary
- Move `isolation: isolate` from `.page-content` to `.postcard-grid` so postcard modal overlays can properly layer above the sticky header
- Fixes portrait postcards getting clipped under the header when opened in the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)