### PR TITLE
style: align left panel spacing and center send button (QPB-89)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -37,7 +37,7 @@
   --offset-logo-lines-left: 130px;
 
   /* Layout sizing — desktop */
-  --width-sidebar: 160px;
+  --width-sidebar: 200px;
   /* sticky-top-sidebar must stay above the header height (header h ≈ 126px on tablet, 140px desktop) */
   --sticky-top-sidebar: 140px;
 
@@ -216,7 +216,7 @@ body {
     --size-logo-lines-w: 96px;
     --size-logo-lines-h: 55px;
     --offset-logo-lines-left: 104px;
-    --width-sidebar: 148px;
+    --width-sidebar: 180px;
     --sticky-top-sidebar: 130px;
     --size-icon-action: 56px;
     --size-icon-send-w: 44px;

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -2,7 +2,7 @@
 .landing-layout {
   display: flex;
   padding: 0 32px 32px;
-  gap: 16px;
+  gap: 32px;
   min-height: calc(100vh - 180px);
 }
 
@@ -127,7 +127,8 @@
 .send-postcard-btn {
   position: fixed;
   bottom: 32px;
-  left: 32px;
+  left: calc(32px + var(--width-sidebar) / 2);
+  transform: translateX(-50%);
   width: var(--width-sidebar);
   z-index: var(--z-send-btn);
   display: flex;
@@ -137,7 +138,7 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  padding: 14px 24px 12px;
+  padding: 14px 32px 12px;
   border-radius: 20px;
   transition: box-shadow 0.3s ease;
 }
@@ -777,12 +778,14 @@
 
   .landing-layout {
     padding: 0 24px 24px;
+    gap: 24px;
   }
 
   .send-postcard-btn {
-    left: 24px;
+    left: calc(24px + var(--width-sidebar) / 2);
+    transform: translateX(-50%);
     width: var(--width-sidebar);
-    padding: 12px 20px 10px;
+    padding: 12px 24px 10px;
   }
 }
 


### PR DESCRIPTION
Notion: [QPB-89](https://www.notion.so/33933daa5a00800d8648d21f356defd2)

## Summary
- Widen `--width-sidebar` to 200px (desktop) / 180px (tablet) so filter labels fit on one line with the new spacing
- Increase `gap` between sidebar and postcard grid to 32px (desktop) / 24px (tablet), replacing the old 16px gap
- Center the send button within the left panel using `calc(offset + sidebar/2)` + `translateX(-50%)`
- Update send button padding to match the new panel proportions at each breakpoint