### PR TITLE
style: send button smaller and left-aligned on mobile (QPB-88)

### DIFF
--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -829,18 +829,23 @@
     position: relative;
   }
 
-  /* Send button floats at bottom-center on mobile */
+  /* Send button floats at bottom-left on mobile */
   .send-postcard-btn {
     bottom: 16px;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 16px;
+    transform: none;
     top: auto;
     right: auto;
-    width: var(--width-sidebar);
+    width: auto;
+    padding: 10px 20px;
     z-index: var(--z-send-btn);
     background: var(--color-white);
     border-radius: 20px;
     border: 2px solid var(--color-lavender);
+  }
+
+  .send-label-suffix {
+    display: none;
   }
 
   /* Hide rainbow border on mobile — solid border used instead */

--- a/posts.html
+++ b/posts.html
@@ -27,7 +27,7 @@ include_modals: true
 
     <button class="send-postcard-btn">
       <img class="send-icon" src="{{ '/assets/icons/postcard.svg' | relative_url }}" alt="" aria-hidden="true">
-      <span class="send-label">Send postcard</span>
+      <span class="send-label">Send<span class="send-label-suffix"> postcard</span></span>
     </button>
   </aside>
 

--- a/posts.html
+++ b/posts.html
@@ -25,7 +25,7 @@ include_modals: true
       </div>
     </div>
 
-    <button class="send-postcard-btn">
+    <button class="send-postcard-btn" aria-label="Send postcard">
       <img class="send-icon" src="{{ '/assets/icons/postcard.svg' | relative_url }}" alt="" aria-hidden="true">
       <span class="send-label">Send<span class="send-label-suffix"> postcard</span></span>
     </button>


### PR DESCRIPTION
Notion: [QPB-88](https://www.notion.so/33933daa5a0080149f4bff4c805bebd8)

## Summary
- On mobile, the send button now sits at bottom-left instead of bottom-center
- Button is smaller (auto width, tighter padding) and shows the icon + "Send" label only — "postcard" suffix is hidden via CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)