### PR TITLE
style: add 3D flip animation for postcard (QPB-90)

### DIFF
--- a/assets/css/postcard.css
+++ b/assets/css/postcard.css
@@ -117,12 +117,13 @@
   position: relative;
   width: 100%;
   transform-style: preserve-3d;
+  transition: transform 0.6s cubic-bezier(0.45, 0, 0.25, 1);
+  will-change: transform;
 }
 
 .postcard-viewer-front {
   width: 100%;
   backface-visibility: hidden;
-  transition: opacity 0.3s ease;
 }
 
 .postcard-viewer-back {
@@ -131,19 +132,42 @@
   position: absolute;
   top: 0;
   left: 0;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  pointer-events: none;
+  transform: rotateY(-180deg);
 }
 
-.postcard-viewer-container.flipped .postcard-viewer-front {
-  opacity: 0;
-  pointer-events: none;
+.postcard-viewer-container.flipped {
+  transform: rotateY(-180deg);
 }
 
-.postcard-viewer-container.flipped .postcard-viewer-back {
-  opacity: 1;
-  pointer-events: auto;
+@media (prefers-reduced-motion: reduce) {
+  .postcard-viewer-container {
+    transition: none;
+  }
+
+  .postcard-viewer-front {
+    transition: opacity 0.3s ease;
+  }
+
+  .postcard-viewer-back {
+    transform: none;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+  }
+
+  .postcard-viewer-container.flipped {
+    transform: none;
+  }
+
+  .postcard-viewer-container.flipped .postcard-viewer-front {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .postcard-viewer-container.flipped .postcard-viewer-back {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 .postcard-viewer-img {

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -462,12 +462,13 @@
   position: relative;
   width: 100%;
   transform-style: preserve-3d;
+  transition: transform 0.6s cubic-bezier(0.45, 0, 0.25, 1);
+  will-change: transform;
 }
 
 .modal-card-front {
   width: 100%;
   backface-visibility: hidden;
-  transition: opacity 0.3s ease;
 }
 
 .modal-card-back {
@@ -476,19 +477,42 @@
   position: absolute;
   top: 0;
   left: 0;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  pointer-events: none;
+  transform: rotateY(-180deg);
 }
 
-.modal-card-container.flipped .modal-card-front {
-  opacity: 0;
-  pointer-events: none;
+.modal-card-container.flipped {
+  transform: rotateY(-180deg);
 }
 
-.modal-card-container.flipped .modal-card-back {
-  opacity: 1;
-  pointer-events: auto;
+@media (prefers-reduced-motion: reduce) {
+  .modal-card-container {
+    transition: none;
+  }
+
+  .modal-card-front {
+    transition: opacity 0.3s ease;
+  }
+
+  .modal-card-back {
+    transform: none;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+  }
+
+  .modal-card-container.flipped {
+    transform: none;
+  }
+
+  .modal-card-container.flipped .modal-card-front {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .modal-card-container.flipped .modal-card-back {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 .modal-front-img,


### PR DESCRIPTION
Notion: [QPB-90](https://www.notion.so/33a33daa5a00800dbc44e97376f64345)

## Summary
- Replaces the opacity crossfade with a true 3D `rotateY` flip animation on both the modal and standalone postcard page
- Back face is pre-rotated at `-180deg` so it becomes front-facing after the container flips
- `0.6s cubic-bezier(0.45, 0, 0.25, 1)` easing gives the rotation a weighted, physical feel
- Adds `prefers-reduced-motion` fallback that restores the original instant opacity swap