### PR TITLE
Fix XSS: use textContent and strip_html for transcript overlay

### DIFF
--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -566,7 +566,7 @@ function toggleReadOverlay() {
     readBtn.setAttribute('aria-label', 'Read transcript');
   } else {
     if (currentPostcard && currentPostcard.dataset.content) {
-      postcardModal.querySelector('.modal-read-text').innerHTML = currentPostcard.dataset.content;
+      postcardModal.querySelector('.modal-read-text').textContent = currentPostcard.dataset.content;
     }
     updateReadOverlaySize();
     overlay.classList.add('active');

--- a/posts.html
+++ b/posts.html
@@ -49,7 +49,7 @@ include_modals: true
            data-date="{{ post.date | date: '%B %d, %Y' }}"
            data-country="{{ post.country }}"
            data-topic="{{ post.topic }}"
-           data-content="{{ post.content | escape }}"
+           data-content="{{ post.content | strip_html | escape }}"
            data-number="{{ post_number }}"
            {% if post.audio %}data-audio="{{ post.audio | relative_url }}"{% endif %}>
         {% if is_new %}

--- a/posts.html
+++ b/posts.html
@@ -49,7 +49,7 @@ include_modals: true
            data-date="{{ post.date | date: '%B %d, %Y' }}"
            data-country="{{ post.country }}"
            data-topic="{{ post.topic }}"
-           data-content="{{ post.content | strip_html | escape }}"
+           data-content="{{ post.content | strip_html | escape_once }}"
            data-number="{{ post_number }}"
            {% if post.audio %}data-audio="{{ post.audio | relative_url }}"{% endif %}>
         {% if is_new %}


### PR DESCRIPTION
Post content was stored as HTML-escaped HTML in data-content, then
re-inserted via innerHTML. The browser decodes HTML entities when reading
dataset.content, so any event handlers in post content (e.g. from
Markdown with inline HTML) would execute.

Fix: strip HTML tags in the template before escaping, and use textContent
to insert the plain text safely in the overlay.

https://claude.ai/code/session_01Nn5n9JVf54K4c6qCwx1UHo