### PR TITLE
feat: add Voice of a Postcard volunteer page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,7 @@
 <footer class="site-footer">
   <nav class="footer-nav" aria-label="Footer navigation">
     <a href="{{ '/about/' | relative_url }}" class="footer-link">About</a>
+    <a href="{{ '/voice/' | relative_url }}" class="footer-link">Voice of a Postcard</a>
     <a href="{{ '/privacy/' | relative_url }}" class="footer-link">Privacy</a>
     {% if site.social.email %}
       <a href="mailto:{{ site.social.email }}" class="footer-link">Contact</a>

--- a/voice.md
+++ b/voice.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Voice of a Postcard
+permalink: /voice/
+---
+
+# Be the Voice of a Postcard
+
+Every postcard on this website is read aloud — not by a machine, but by a real person. Someone who chose to lend their voice to a stranger's story.
+
+If you've ever received a postcard, you know that moment when you read it out loud, almost instinctively. That's exactly what this is. A way to make these stories feel a little more human, a little more warm, a little more like they were meant to be shared.
+
+## How it works
+
+When you sign up, your name goes into a pool of volunteers. Each time a new postcard is published, I'll randomly pick someone from the list and reach out with the postcard text. You record yourself reading it — no studio, no script, no performance needed. Just your voice, naturally. Then you send it back, and it becomes part of the postcard forever.
+
+That's it.
+
+## A few things worth knowing
+
+- Any voice, any accent, any language background — all welcome. There's no right way to sound.
+- You'll only be contacted when it's your turn, and you can always say no or pass.
+- Each volunteer chooses whether their name appears on the Credits page or stays anonymous. Either is completely fine.


### PR DESCRIPTION
## Summary
- Adds new `/voice/` page explaining the volunteer voice-reading program for postcards
- Links to the page from the footer nav as "Voice of a Postcard"

🤖 Generated with [Claude Code](https://claude.com/claude-code)