### PR TITLE
feat: add About page content with modern letter design (QPB-81, QPB-60)

### DIFF
--- a/about.md
+++ b/about.md
@@ -3,8 +3,26 @@ layout: default
 title: About
 permalink: /about/
 ---
-🚧🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🚧
 
-This website is under construction. Please come back later.
+<link rel="stylesheet" href="{{ '/assets/css/about.css' | relative_url }}">
 
-🚧🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈🚧
+<article class="about-letter">
+  <div class="letter-accent"></div>
+  <header class="letter-header">
+    <p class="letter-location">Berlin, June 2026</p>
+  </header>
+  <div class="letter-body">
+    <p class="letter-greeting">Dear queers and allies,</p>
+    <p>Queer Postbox is a collection of queer stories on postcards from around the world.</p>
+    <p>The idea is rooted in two projects that are dear to me. The first one, <a href="https://www.postcrossing.com" target="_blank" rel="noopener noreferrer">postcrossing.com</a> is a global community of random people from around the world who love sending and receiving postcards. There I encouraged others to write me about how LGBT people are seen in their country and share their opinion. The vast majority of messages I got were supporting, wholesome, and heartwarming, and one in particular from a very conservative country from an LGBT ally, brought tears of joy to my eyes. Stories like this need to be heard and I hope Queer Postbox will become a window into what it means to be queer in the world today. My second inspiration is <a href="https://postsecret.com" target="_blank" rel="noopener noreferrer">postsecret.com</a>'s format of sending a postcard to a PO box. If you're a postcards fan like I am, go check them out!</p>
+    <p>As a gay man growing up in Romania, I vividly remember the moments when I felt like an outsider. I was 14 when my country fully decriminalized homosexuality, and that moment is still vivid in my memory. I hope Queer Postbox is going to be an inspiration for others like me who needed to hear, again and again, that things are going to get better and that life is worth fighting for.</p>
+    <p>Queer Postbox is a one year project whose purpose is to document authentic stories that reflect our current times. If you want to take part, please send a postcard; you have time until about July 2027. Write on the postcard anything you'd like to share. Your coming out story, or how you were outed. The day you found your chosen family. What it feels like to be the parent of a queer child. A mental health struggle you've never said out loud. It's your story!</p>
+    <p>This project would not have been possible without my friend Mia. She's been one of my close friends for a bit over a decade. I'm deeply thankful for her belief in this project, her support, the UI/UX foundations she set, the logo and tagline she designed, and for pushing me to bring it to life. Do you like the reply functionality? It was totally her idea!</p>
+    <p>To make Queer Postbox feel more personal, warmer, more accessible, each postcard has a voice. It's supposed to mimic that moment when you receive a postcard and you read it out loud. I'm still looking for more volunteers to be the voice of postcards. If you're interested, check out Voice of a Postcard.</p>
+    <p>I hope going through this collection of postcards would leave you inspired, hopeful for a better world, and a reminder that we are not alone.</p>
+  </div>
+  <footer class="letter-signoff">
+    <p class="letter-closing">xoxo,</p>
+    <p class="letter-name">Christian</p>
+  </footer>
+</article>

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -1,0 +1,131 @@
+/* About — modern letter */
+
+.about-letter {
+  position: relative;
+  max-width: 640px;
+  margin: 48px auto 64px;
+  padding: 48px 56px;
+  background: var(--color-light-1);
+  border-radius: 12px;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.04),
+    0 4px 12px rgba(0, 0, 0, 0.03);
+  overflow: hidden;
+}
+
+.letter-accent {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--color-lavender-bright);
+}
+
+.letter-location {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--color-gray-3);
+  margin-bottom: 32px;
+}
+
+.letter-greeting {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 22px;
+  color: var(--color-lavender-dark);
+  margin-bottom: 24px;
+}
+
+.letter-body p {
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.3px;
+  color: var(--color-gray-5);
+  margin-bottom: 20px;
+}
+
+.letter-body p:last-child {
+  margin-bottom: 0;
+}
+
+.letter-body a {
+  color: var(--color-lavender-dark);
+  text-decoration: underline;
+  text-decoration-color: var(--color-lavender-bright);
+  text-underline-offset: 2px;
+  transition: color 0.2s ease;
+}
+
+.letter-body a:hover {
+  color: var(--color-lavender);
+}
+
+.letter-signoff {
+  margin-top: 40px;
+}
+
+.letter-closing {
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.3px;
+  color: var(--color-gray-4);
+  margin-bottom: 4px;
+}
+
+.letter-name {
+  font-family: "Bradley Hand", "Segoe Script", cursive;
+  font-weight: 400;
+  font-size: 22px;
+  color: var(--color-lavender-dark);
+}
+
+/* Tablet */
+@media (max-width: 1024px) {
+  .about-letter {
+    padding: 40px 44px;
+    margin: 32px 24px 48px;
+  }
+
+  .letter-greeting {
+    font-size: 20px;
+  }
+
+  .letter-name {
+    font-size: 20px;
+  }
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .about-letter {
+    padding: 32px 24px;
+    margin: 16px 16px 32px;
+    border-radius: 8px;
+  }
+
+  .letter-location {
+    font-size: 13px;
+    margin-bottom: 24px;
+  }
+
+  .letter-greeting {
+    font-size: 18px;
+    margin-bottom: 20px;
+  }
+
+  .letter-body p {
+    font-size: 15px;
+  }
+
+  .letter-name {
+    font-size: 18px;
+  }
+
+  .letter-signoff {
+    margin-top: 32px;
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the placeholder About page with Christian's personal letter about the project's origins, purpose, and acknowledgments
- Style the page as a modern letter card with a warm paper background, lavender accent bar, and handwritten cursive signature
- Add responsive styling for tablet and mobile breakpoints
- New `assets/css/about.css` for page-specific letter styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)