### PR TITLE
Improve send/reply postcard modals

### DIFF
--- a/_includes/modals/reply.html
+++ b/_includes/modals/reply.html
@@ -5,7 +5,7 @@
       <img src="{{ '/assets/icons/close.svg' | relative_url }}" alt="Close" width="20" height="20">
     </button>
     <div class="reply-content">
-      <h2 class="reply-title">To send a reply:</h2>
+      <h2 class="reply-title">Send a reply!</h2>
       <p class="reply-instruction">Write the same number displayed above the postcard on the top left side of your reply postcard.</p>
       <div class="reply-postcard-example">
         <div class="reply-example-number">#123</div>
@@ -13,7 +13,7 @@
           <div class="reply-example-left">
             <p class="reply-example-meta">City, Date</p>
             <p class="reply-example-heading">Your message</p>
-            <p class="reply-example-text">Write your story, thoughts, or reply here...</p>
+            <p class="reply-example-text">Write your reply to this postcard here...</p>
             <p class="reply-example-sign">/Your name (optional)</p>
           </div>
           <div class="reply-example-divider"></div>

--- a/_includes/modals/send.html
+++ b/_includes/modals/send.html
@@ -5,8 +5,8 @@
       <img src="{{ '/assets/icons/close.svg' | relative_url }}" alt="Close" width="20" height="20">
     </button>
     <div class="reply-content">
-      <h2 class="reply-title">Send a postcard</h2>
-      <p class="reply-instruction">Write your story, thoughts, or message on a postcard and post it to:</p>
+      <h2 class="reply-title">Send your story on a postcard!</h2>
+      <p class="reply-instruction">It can be your coming out, how you learned to accept yourself, finding your chosen family, a struggle you&rsquo;ve never said out loud, or anything else you&rsquo;d like to share. When it&rsquo;s ready, post it here:</p>
       <div class="reply-postcard-example">
         <div class="reply-example-body">
           <div class="reply-example-left">

--- a/assets/css/posts.css
+++ b/assets/css/posts.css
@@ -653,17 +653,37 @@
 }
 
 .reply-card {
-  background: var(--color-white);
+  position: relative;
+  background: var(--color-light-1);
   border-radius: 16px;
-  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
-  width: 490px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.12);
+  width: 580px;
   max-width: 95vw;
   max-height: 90vh;
   overflow-y: auto;
-  padding: 16px;
+  padding: 40px 40px 44px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+}
+
+/* Rainbow accent bar across the top — mirrors the About letter accent */
+.reply-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--color-pink),
+    var(--color-orange),
+    var(--color-yellow),
+    var(--color-green),
+    var(--color-blue),
+    var(--color-purple)
+  );
 }
 
 .reply-close,
@@ -685,20 +705,20 @@
 
 .reply-title {
   font-family: var(--font-display);
-  font-weight: 500;
-  font-size: 24px;
-  color: var(--color-black);
+  font-weight: 700;
+  font-size: 26px;
+  color: var(--color-lavender-dark);
   text-align: center;
 }
 
 .reply-instruction {
   font-family: var(--font-body);
   font-size: 16px;
-  line-height: 20px;
-  letter-spacing: 1.28px;
-  color: var(--color-black);
-  text-align: center;
-  max-width: 400px;
+  line-height: 1.6;
+  letter-spacing: 0.3px;
+  color: var(--color-gray-5);
+  text-align: left;
+  width: 100%;
 }
 
 /* Example postcard in reply modal */
@@ -706,11 +726,13 @@
   background: var(--color-white);
   border: 1px solid var(--color-gray-1);
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
-  width: 420px;
-  max-width: 100%;
+  width: 100%;
+  aspect-ratio: 3 / 2;
   padding: 20px 24px;
   position: relative;
   border-radius: 2px;
+  display: flex;
+  flex-direction: column;
 }
 
 .reply-example-number {
@@ -718,8 +740,9 @@
   font-weight: 500;
   font-size: 20px;
   color: var(--color-black);
-  border: 2px solid var(--color-warning);
+  border: 2px solid var(--color-lavender);
   display: inline-block;
+  align-self: flex-start;
   padding: 2px 8px;
   margin-bottom: 8px;
 }
@@ -727,7 +750,8 @@
 .reply-example-body {
   display: flex;
   gap: 0;
-  min-height: 200px;
+  flex: 1;
+  min-height: 0;
 }
 
 .reply-example-left {
@@ -736,7 +760,10 @@
   font-family: 'Courier New', monospace;
   font-size: 13px;
   line-height: 1.4;
-  color: var(--color-black);
+  color: var(--color-gray-3);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
 }
 
 .reply-example-meta {
@@ -748,8 +775,9 @@
 
 .reply-example-heading {
   font-style: italic;
+  margin-top: auto;
   margin-bottom: 8px;
-  text-decoration: underline;
+  color: var(--color-gray-3);
 }
 
 .reply-example-text {
@@ -760,6 +788,8 @@
 
 .reply-example-sign {
   font-style: italic;
+  margin-bottom: auto;
+  color: var(--color-gray-3);
 }
 
 .reply-example-divider {
@@ -774,13 +804,32 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  justify-content: flex-start;
 }
 
 .reply-example-stamp {
   width: 39px;
   height: 46px;
-  border: 1px solid var(--color-black);
-  margin-bottom: 16px;
+  padding: 3px;
+  background: var(--color-white);
+  border: 1px dashed var(--color-gray-2);
+  border-radius: 2px;
+}
+
+.reply-example-stamp::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    180deg,
+    var(--color-pink) 0 16.66%,
+    var(--color-orange) 16.66% 33.33%,
+    var(--color-yellow) 33.33% 50%,
+    var(--color-green) 50% 66.66%,
+    var(--color-blue) 66.66% 83.33%,
+    var(--color-purple) 83.33% 100%
+  );
 }
 
 .reply-example-address {
@@ -788,7 +837,12 @@
   font-size: 13px;
   line-height: 1.5;
   text-align: right;
-  color: var(--color-black);
+  color: var(--color-gray-3);
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.reply-example-address p:first-child {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary

Redesigns the "Send a postcard" and reply pop-ups to feel warmer and more on-brand, and makes the copy clearer about what to write.

- Reworded the send modal: title "Send your story on a postcard!" with an expanded intro listing example things to write about. Reply modal title updated to "Send a reply!".
- Brand polish on the shared modal styling: rainbow accent bar across the top, lavender headings, a pride-colored stamp, warmer background, and a larger modal with more padding.
- The example postcard now uses a realistic 3:2 ratio, with City/Date and the stamp pinned to the top and the message block + address vertically centered below.
- Unified the example text to a soft gray, removed underlines except on the recipient name, and recolored the reply number badge from red to lavender.

Changes apply to both modals since they share the `.reply-*` styles.